### PR TITLE
v0.2 stability batch: recipe-store sync, dependency type cascade, boot-resume (Variants A+B), atomic applied.toml

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/carlosprados/keystone/internal/artifact"
@@ -114,18 +115,32 @@ func New(opts Options) *Agent {
 		a.planPath = snap.Plan.Path
 		a.planStatus = snap.Plan.Status
 		a.planErr = snap.Plan.Error
-		for _, ci := range snap.Components {
-			a.comps.Upsert(ci)
-		}
 		a.planComps = snap.PlanComponents
 
-		// Resume the last plan unless the operator explicitly stopped it or
-		// the last persisted status was a dry-run (which never installed
-		// anything). The previous code only resumed on "running" / "failed",
-		// which left the agent silent after an interrupted apply: the status
-		// stayed at "applying" forever and no component was ever supervised
-		// even though /healthz reported OK.
-		if a.planPath != "" && shouldResumeLastPlan(a.planStatus) {
+		resume := a.planPath != "" && shouldResumeLastPlan(a.planStatus)
+
+		// Variant B recovery: when the previous agent run did not exit via
+		// Close() (SIGKILL, segfault, OOM kill), its child processes are
+		// reparented to PID 1 and continue running, but the new agent has
+		// no runner handles for them. Reap any orphans recorded in the
+		// snapshot before reconcile reads the in-memory state, then reset
+		// the persisted "running" state so the resume re-applies from
+		// scratch (the snapshot's component states are informational
+		// post-crash, not authoritative).
+		if resume {
+			if reaped := reapOrphanedComponents(snap.Components); reaped > 0 {
+				log.Printf("[agent] reaped %d orphan component process(es) from previous run", reaped)
+			}
+		}
+		for _, ci := range snap.Components {
+			if resume {
+				ci.State = "stopped"
+				ci.PID = 0
+			}
+			a.comps.Upsert(ci)
+		}
+
+		if resume {
 			if strings.EqualFold(strings.TrimSpace(a.planStatus), "applying") {
 				log.Printf("[agent] previous apply was interrupted (status=applying); recovering by re-applying from scratch")
 			}
@@ -1266,6 +1281,78 @@ func (a *Agent) stopComponent(name string) {
 	}
 	shCancel()
 	log.Printf("agent: stopComponent done name=%s", name)
+}
+
+// reapOrphanedComponents signals every PID recorded in the supplied component
+// list that still looks like an orphan from the previous agent run, then
+// returns how many PIDs were signalled.
+//
+// "Orphan" here is a process whose parent is PID 1 (init) — the signature of
+// a process whose original parent died without reaping it (typically: previous
+// keystone agent killed by SIGKILL / crashed). For each such PID the helper
+// sends SIGTERM, waits up to ~2 s for the process to exit, and escalates to
+// SIGKILL if it is still alive. Processes whose parent is not init are left
+// untouched: that PID has likely been reused by something unrelated.
+//
+// This is required because Variant B of the boot-resume bug: after a crash,
+// children survive as init-owned orphans the new agent has no handle to. The
+// snapshot's "running" state is informational at that point, not
+// authoritative — reapOrphanedComponents removes the orphans so the resumed
+// plan starts fresh without port/file collisions.
+func reapOrphanedComponents(comps []store.ComponentInfo) int {
+	reaped := 0
+	for _, ci := range comps {
+		if ci.PID <= 0 {
+			continue
+		}
+		if !processIsInitOrphan(ci.PID) {
+			continue
+		}
+		log.Printf("[agent] reaping orphan from previous run: component=%s pid=%d", ci.Name, ci.PID)
+		_ = syscall.Kill(ci.PID, syscall.SIGTERM)
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if !processExists(ci.PID) {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		if processExists(ci.PID) {
+			_ = syscall.Kill(ci.PID, syscall.SIGKILL)
+		}
+		reaped++
+	}
+	return reaped
+}
+
+// processExists reports whether a process with this PID is reachable from the
+// current process (sig 0 doesn't deliver anything, it just probes existence
+// and permission).
+func processExists(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	return syscall.Kill(pid, 0) == nil
+}
+
+// processIsInitOrphan reports whether the process with PID is currently
+// parented by PID 1 (init) on Linux. Returns false for any read/parse error
+// or when the parent is not init; the conservative default is to leave the
+// PID alone in those cases.
+func processIsInitOrphan(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if rest, ok := strings.CutPrefix(line, "PPid:"); ok {
+			return strings.TrimSpace(rest) == "1"
+		}
+	}
+	return false
 }
 
 // shouldResumeLastPlan decides whether the agent should re-apply the last

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -269,10 +269,14 @@ func (a *Agent) applyPlan(planPath string) error {
 	metaToComp := map[string]string{}
 	compRecipes := map[string]*recipe.Recipe{}
 	for _, it := range p.Components {
-		r, _, digest, err := a.resolveRecipeRef(it.RecipePath)
+		r, resolvedPath, digest, err := a.resolveRecipeRef(it.RecipePath)
 		if err != nil {
 			return fmt.Errorf("failed to load recipe for %s (path: %s): %w", it.Name, it.RecipePath, err)
 		}
+		// Mirror plan-driven recipes into the local recipe store so that
+		// GET /v1/recipes reflects what is actually supervised. Errors are
+		// non-fatal: a failed store write must not block the install.
+		a.mirrorRecipeToStore(it.Name, r.Metadata.Name, r.Metadata.Version, resolvedPath)
 		loadedList = append(loadedList, loaded{
 			item:   it,
 			rec:    r,
@@ -1244,6 +1248,22 @@ func (a *Agent) stopComponent(name string) {
 	}
 	shCancel()
 	log.Printf("agent: stopComponent done name=%s", name)
+}
+
+// mirrorRecipeToStore copies the recipe file at resolvedPath into the
+// local recipe store under (name, version). Used by applyPlan to keep
+// GET /v1/recipes in sync with what is actually supervised. Errors are
+// non-fatal: a failed read or write must not block the install (e.g.
+// read-only mount, racing API call); they are logged and swallowed.
+func (a *Agent) mirrorRecipeToStore(compName, recipeName, recipeVersion, resolvedPath string) {
+	content, err := os.ReadFile(resolvedPath)
+	if err != nil {
+		log.Printf("[agent] component=%s msg=failed to read recipe content for store sync (path=%s): %v", compName, resolvedPath, err)
+		return
+	}
+	if err := a.recipes.Save(recipeName, recipeVersion, string(content), true); err != nil {
+		log.Printf("[agent] component=%s msg=failed to sync recipe %s:%s to store: %v", compName, recipeName, recipeVersion, err)
+	}
 }
 
 // AddRecipe saves a recipe to the local store.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -288,15 +288,20 @@ func (a *Agent) applyPlan(planPath string) error {
 	}
 	// Second pass: compute deps among plan components using recipe dependencies
 	for _, l := range loadedList {
-		// compute dep component names
+		// compute dep component names and per-edge type
 		var depNames []string
+		var depTypes map[string]string
 		for _, d := range l.rec.Dependencies {
+			if err := validateDepType(d.Type); err != nil {
+				return fmt.Errorf("component %s dependency %q: %w", l.item.Name, d.Name, err)
+			}
+			depType := normalizeDepType(d.Type)
 			compName, ok := metaToComp[d.Name]
 			if !ok {
-				if isHardDependency(d.Type) {
-					return fmt.Errorf("component %s has hard dependency %q not present in plan", l.item.Name, d.Name)
+				if isPresenceMandatory(d.Type) {
+					return fmt.Errorf("component %s has mandatory (%s) dependency %q not present in plan", l.item.Name, depType, d.Name)
 				}
-				log.Printf("[agent] component=%s msg=soft dependency %q not present in plan (ignored)", l.item.Name, d.Name)
+				log.Printf("[agent] component=%s msg=optional (%s) dependency %q not present in plan (ignored)", l.item.Name, depType, d.Name)
 				continue
 			}
 			depRec := compRecipes[compName]
@@ -305,13 +310,17 @@ func (a *Agent) applyPlan(planPath string) error {
 				return fmt.Errorf("component %s dependency %q has invalid version constraint %q: %w", l.item.Name, d.Name, d.Version, derr)
 			}
 			if !satisfied {
-				if isHardDependency(d.Type) {
-					return fmt.Errorf("component %s hard dependency %q constraint %q not satisfied by %s", l.item.Name, d.Name, d.Version, depRec.Metadata.Version)
+				if isPresenceMandatory(d.Type) {
+					return fmt.Errorf("component %s mandatory (%s) dependency %q constraint %q not satisfied by %s", l.item.Name, depType, d.Name, d.Version, depRec.Metadata.Version)
 				}
-				log.Printf("[agent] component=%s msg=soft dependency %q constraint %q not satisfied by %s (ignored)", l.item.Name, d.Name, d.Version, depRec.Metadata.Version)
+				log.Printf("[agent] component=%s msg=optional (%s) dependency %q constraint %q not satisfied by %s (ignored)", l.item.Name, depType, d.Name, d.Version, depRec.Metadata.Version)
 				continue
 			}
 			depNames = append(depNames, compName)
+			if depTypes == nil {
+				depTypes = make(map[string]string)
+			}
+			depTypes[compName] = depType
 		}
 		planMap = append(planMap, state.PlanComponent{
 			Name:          l.item.Name,
@@ -321,6 +330,7 @@ func (a *Agent) applyPlan(planPath string) error {
 			RecipeID:      l.id,
 			RecipeDigest:  l.digest,
 			Deps:          depNames,
+			DepTypes:      depTypes,
 		})
 	}
 	// Build supervisor components now using computed deps
@@ -1304,8 +1314,13 @@ func (a *Agent) ListRecipes() ([]string, error) {
 	return a.recipes.List()
 }
 
-// planDependentsTopological returns dependents of 'name' in topological order (closest first -> farthest last).
-func (a *Agent) planDependentsTopological(name string) []string {
+// planDependentsTopological returns dependents of 'name' in topological order
+// (closest first -> farthest last). When cascadingOnly is true, only edges
+// whose declared type implies a restart cascade ("hard", "soft") are followed;
+// "ordering" edges and any unknown/missing type defaulting to a cascade
+// behaviour different from hard/soft are skipped. An empty/missing dep type
+// in DepTypes is treated as "hard" for backward compatibility.
+func (a *Agent) planDependentsTopological(name string, cascadingOnly bool) []string {
 	// Build graph: dep -> comp
 	edges := map[string][]string{}
 	indeg := map[string]int{}
@@ -1315,6 +1330,12 @@ func (a *Agent) planDependentsTopological(name string) []string {
 	}
 	for _, pc := range a.planComps {
 		for _, d := range pc.Deps {
+			if cascadingOnly {
+				t := pc.DepTypes[d]
+				if !shouldCascadeRestart(t) {
+					continue
+				}
+			}
 			edges[d] = append(edges[d], pc.Name)
 			indeg[pc.Name]++
 		}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -119,8 +119,16 @@ func New(opts Options) *Agent {
 		}
 		a.planComps = snap.PlanComponents
 
-		// Resume plan if it was running or failed
-		if a.planPath != "" && (a.planStatus == "running" || a.planStatus == "failed") {
+		// Resume the last plan unless the operator explicitly stopped it or
+		// the last persisted status was a dry-run (which never installed
+		// anything). The previous code only resumed on "running" / "failed",
+		// which left the agent silent after an interrupted apply: the status
+		// stayed at "applying" forever and no component was ever supervised
+		// even though /healthz reported OK.
+		if a.planPath != "" && shouldResumeLastPlan(a.planStatus) {
+			if strings.EqualFold(strings.TrimSpace(a.planStatus), "applying") {
+				log.Printf("[agent] previous apply was interrupted (status=applying); recovering by re-applying from scratch")
+			}
 			go func() {
 				log.Printf("[agent] resuming last plan: %s", a.planPath)
 				if err := a.ApplyPlan(a.planPath, false); err != nil {
@@ -1258,6 +1266,23 @@ func (a *Agent) stopComponent(name string) {
 	}
 	shCancel()
 	log.Printf("agent: stopComponent done name=%s", name)
+}
+
+// shouldResumeLastPlan decides whether the agent should re-apply the last
+// persisted plan at startup based on the persisted plan status.
+//
+// The agent resumes for any status that represents an active or interrupted
+// deployment, including the previously-buggy "applying" case (the apply was
+// killed mid-flight; without resuming, the plan stays silently unsupervised).
+// It refuses to resume only when the operator explicitly stopped the plan or
+// when the last persisted state was a dry-run that never installed anything.
+func shouldResumeLastPlan(planStatus string) bool {
+	switch strings.ToLower(strings.TrimSpace(planStatus)) {
+	case "stopped", "dry-run":
+		return false
+	default:
+		return true
+	}
 }
 
 // mirrorRecipeToStore copies the recipe file at resolvedPath into the

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1453,16 +1453,49 @@ func topoOrder(edges map[string][]string, indeg map[string]int) []string {
 }
 
 // ApplyPlanContent saves the raw plan TOML to a local file and applies it.
+//
+// The canonical "last applied" file (runtime/plans/applied.toml) is touched
+// only after a successful real apply. The candidate plan is first staged to a
+// sibling .staging file: a dry-run runs the reconcile against the staged file
+// and discards it, while a failed real apply leaves applied.toml intact so
+// that the next resume (and the in-flight rollback inside applyPlan, which
+// reads `oldPlanPath = a.planPath`) still sees the previously-known-good plan
+// instead of the rejected candidate.
 func (a *Agent) ApplyPlanContent(content string, dry bool) error {
 	dir := filepath.Join("runtime", "plans")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
-	path := filepath.Join(dir, "applied.toml")
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+	finalPath := filepath.Join(dir, "applied.toml")
+	stagedPath := finalPath + ".staging"
+
+	if err := os.WriteFile(stagedPath, []byte(content), 0o644); err != nil {
 		return err
 	}
-	return a.ApplyPlan(path, dry)
+
+	if err := a.ApplyPlan(stagedPath, dry); err != nil {
+		_ = os.Remove(stagedPath)
+		return err
+	}
+	if dry {
+		_ = os.Remove(stagedPath)
+		return nil
+	}
+
+	// Promote the staged file onto the canonical applied.toml. The rename
+	// is atomic on POSIX filesystems for files in the same directory.
+	if err := os.Rename(stagedPath, finalPath); err != nil {
+		_ = os.Remove(stagedPath)
+		return fmt.Errorf("apply: promote staged plan to %s: %w", finalPath, err)
+	}
+	// Re-point the in-memory plan path at the canonical location so the
+	// snapshot (and any future resume) does not reference the staged path
+	// that no longer exists.
+	a.mu.Lock()
+	a.planPath = finalPath
+	a.mu.Unlock()
+	a.persistSnapshot()
+	return nil
 }
 
 // Helpers for synchronous restart

--- a/internal/agent/agent_delete_test.go
+++ b/internal/agent/agent_delete_test.go
@@ -9,6 +9,53 @@ import (
 	"github.com/carlosprados/keystone/internal/store"
 )
 
+func TestMirrorRecipeToStore(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "mirror-recipe-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	storeDir := filepath.Join(tempDir, "recipes")
+	a := &Agent{recipes: store.NewRecipeStore(storeDir)}
+
+	src := filepath.Join(tempDir, "foo.recipe.toml")
+	original := []byte("# recipe v1\n[metadata]\nname=\"foo\"\nversion=\"1.0.0\"\n")
+	if err := os.WriteFile(src, original, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 1. Happy path: store gets the content.
+	a.mirrorRecipeToStore("compA", "foo", "1.0.0", src)
+	got, err := os.ReadFile(filepath.Join(storeDir, "foo-1.0.0.toml"))
+	if err != nil {
+		t.Fatalf("expected recipe written to store: %v", err)
+	}
+	if string(got) != string(original) {
+		t.Errorf("store content mismatch: got %q want %q", got, original)
+	}
+
+	// 2. Re-mirror same name:version with edited content overwrites (force=true).
+	edited := []byte("# recipe v1 edited\n[metadata]\nname=\"foo\"\nversion=\"1.0.0\"\n")
+	if err := os.WriteFile(src, edited, 0644); err != nil {
+		t.Fatal(err)
+	}
+	a.mirrorRecipeToStore("compA", "foo", "1.0.0", src)
+	got, err = os.ReadFile(filepath.Join(storeDir, "foo-1.0.0.toml"))
+	if err != nil {
+		t.Fatalf("expected recipe still present after re-mirror: %v", err)
+	}
+	if string(got) != string(edited) {
+		t.Errorf("expected store to reflect edited content, got %q", got)
+	}
+
+	// 3. Source path missing: must not panic, must not abort caller.
+	a.mirrorRecipeToStore("compB", "missing", "0.0.1", filepath.Join(tempDir, "does-not-exist.toml"))
+	if _, err := os.Stat(filepath.Join(storeDir, "missing-0.0.1.toml")); !os.IsNotExist(err) {
+		t.Errorf("store should not contain a recipe whose source was unreadable, stat err=%v", err)
+	}
+}
+
 func TestAgentDeleteRecipeSafety(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "agent-test-*")
 	if err != nil {

--- a/internal/agent/boot_resume_test.go
+++ b/internal/agent/boot_resume_test.go
@@ -1,0 +1,27 @@
+package agent
+
+import "testing"
+
+func TestShouldResumeLastPlan(t *testing.T) {
+	cases := []struct {
+		status string
+		want   bool
+		reason string
+	}{
+		{"", true, "empty (legacy or first run) resumes"},
+		{"running", true, "running resumes"},
+		{"failed", true, "failed resumes"},
+		{"applying", true, "interrupted apply resumes (the v0.1.0 boot-resume bug)"},
+		{"APPLYING", true, "case-insensitive"},
+		{"  applying  ", true, "trims whitespace"},
+		{"stopped", false, "explicit stop is respected"},
+		{"STOPPED", false, "case-insensitive stop"},
+		{"dry-run", false, "dry-run never installed anything, do not resume"},
+		{"unknown-future-status", true, "unknown values default to resume (safer than silent skip)"},
+	}
+	for _, c := range cases {
+		if got := shouldResumeLastPlan(c.status); got != c.want {
+			t.Errorf("shouldResumeLastPlan(%q)=%v, want %v (%s)", c.status, got, c.want, c.reason)
+		}
+	}
+}

--- a/internal/agent/boot_resume_test.go
+++ b/internal/agent/boot_resume_test.go
@@ -1,6 +1,70 @@
 package agent
 
-import "testing"
+import (
+	"os"
+	"testing"
+
+	"github.com/carlosprados/keystone/internal/store"
+)
+
+func TestProcessExists(t *testing.T) {
+	if !processExists(os.Getpid()) {
+		t.Errorf("processExists(self) returned false; the test process exists")
+	}
+	for _, bad := range []int{0, -1, -42} {
+		if processExists(bad) {
+			t.Errorf("processExists(%d) returned true; non-positive PIDs are never valid", bad)
+		}
+	}
+	// 99999999 is well above PID_MAX on Linux (4194303 default) so the lookup
+	// must fail with ESRCH.
+	if processExists(99999999) {
+		t.Errorf("processExists(99999999) returned true; that PID cannot exist")
+	}
+}
+
+func TestProcessIsInitOrphan(t *testing.T) {
+	// The Go test runner is our parent; we are not parented by init.
+	if processIsInitOrphan(os.Getpid()) {
+		t.Errorf("test process must not look like an init orphan")
+	}
+	// PID 1 is init itself: PPid is 0, not 1.
+	if processIsInitOrphan(1) {
+		t.Errorf("init (pid 1) has PPid=0 and must not be classified as init orphan")
+	}
+	for _, bad := range []int{0, -1, 99999999} {
+		if processIsInitOrphan(bad) {
+			t.Errorf("processIsInitOrphan(%d) returned true; expected false for invalid/unknown PIDs", bad)
+		}
+	}
+}
+
+func TestReapOrphanedComponents_NoOpCases(t *testing.T) {
+	// Empty list: nothing to reap, no panic.
+	if got := reapOrphanedComponents(nil); got != 0 {
+		t.Errorf("nil list: reaped=%d, want 0", got)
+	}
+	// PID <= 0 entries are silently skipped.
+	if got := reapOrphanedComponents([]store.ComponentInfo{
+		{Name: "a", PID: 0},
+		{Name: "b", PID: -1},
+	}); got != 0 {
+		t.Errorf("non-positive PIDs must be skipped, reaped=%d", got)
+	}
+	// A PID that is alive but is NOT parented by init (the test process is
+	// parented by the test runner) must not be reaped.
+	if got := reapOrphanedComponents([]store.ComponentInfo{
+		{Name: "self", PID: os.Getpid()},
+	}); got != 0 {
+		t.Errorf("non-init-parented PID must not be reaped, reaped=%d", got)
+	}
+	// A clearly-non-existent PID is skipped (read /proc/<pid>/status fails).
+	if got := reapOrphanedComponents([]store.ComponentInfo{
+		{Name: "gone", PID: 99999999},
+	}); got != 0 {
+		t.Errorf("non-existent PID must not be reaped, reaped=%d", got)
+	}
+}
 
 func TestShouldResumeLastPlan(t *testing.T) {
 	cases := []struct {

--- a/internal/agent/dep_type_test.go
+++ b/internal/agent/dep_type_test.go
@@ -1,0 +1,177 @@
+package agent
+
+import (
+	"encoding/json"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/carlosprados/keystone/internal/state"
+)
+
+func TestNormalizeDepType(t *testing.T) {
+	cases := map[string]string{
+		"":          "hard",
+		"   ":       "hard",
+		"hard":      "hard",
+		"HARD":      "hard",
+		"  Soft  ":  "soft",
+		"ordering":  "ordering",
+		"weird-val": "weird-val", // normalize keeps unknown to surface via validateDepType
+	}
+	for in, want := range cases {
+		if got := normalizeDepType(in); got != want {
+			t.Errorf("normalizeDepType(%q)=%q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestValidateDepType(t *testing.T) {
+	for _, ok := range []string{"", "hard", "HARD", "soft", "ordering", "  ordering  "} {
+		if err := validateDepType(ok); err != nil {
+			t.Errorf("validateDepType(%q) unexpectedly errored: %v", ok, err)
+		}
+	}
+	for _, bad := range []string{"weak", "must", "after", "before", "partof"} {
+		if err := validateDepType(bad); err == nil {
+			t.Errorf("validateDepType(%q) expected error, got nil", bad)
+		}
+	}
+}
+
+func TestPresenceAndCascadeMatrix(t *testing.T) {
+	cases := []struct {
+		typ                string
+		wantMandatory      bool
+		wantCascadeRestart bool
+	}{
+		{"", true, true},          // empty defaults to hard
+		{"hard", true, true},      // hard: mandatory + cascade
+		{"HARD", true, true},      // case-insensitive
+		{"soft", false, true},     // soft: optional + cascade (this is the bug being fixed)
+		{"ordering", true, false}, // ordering: mandatory + NO cascade
+	}
+	for _, c := range cases {
+		if got := isPresenceMandatory(c.typ); got != c.wantMandatory {
+			t.Errorf("isPresenceMandatory(%q)=%v, want %v", c.typ, got, c.wantMandatory)
+		}
+		if got := shouldCascadeRestart(c.typ); got != c.wantCascadeRestart {
+			t.Errorf("shouldCascadeRestart(%q)=%v, want %v", c.typ, got, c.wantCascadeRestart)
+		}
+	}
+}
+
+// Plan shape used in the cascade tests:
+//
+//	sink  <- hardConsumer    (hard:    cascades)
+//	sink  <- softConsumer    (soft:    cascades)
+//	sink  <- orderingClient  (ordering: does NOT cascade)
+//	hardConsumer <- transitive (hard: cascades)  — should also be pulled in
+func newCascadePlan() []state.PlanComponent {
+	return []state.PlanComponent{
+		{Name: "sink"},
+		{
+			Name:     "hardConsumer",
+			Deps:     []string{"sink"},
+			DepTypes: map[string]string{"sink": "hard"},
+		},
+		{
+			Name:     "softConsumer",
+			Deps:     []string{"sink"},
+			DepTypes: map[string]string{"sink": "soft"},
+		},
+		{
+			Name:     "orderingClient",
+			Deps:     []string{"sink"},
+			DepTypes: map[string]string{"sink": "ordering"},
+		},
+		{
+			Name:     "transitive",
+			Deps:     []string{"hardConsumer"},
+			DepTypes: map[string]string{"hardConsumer": "hard"},
+		},
+	}
+}
+
+func sortedCopy(in []string) []string {
+	out := append([]string(nil), in...)
+	sort.Strings(out)
+	return out
+}
+
+func TestPlanDependentsTopological_AllVsCascading(t *testing.T) {
+	a := &Agent{planComps: newCascadePlan()}
+
+	// cascadingOnly=false -> every dependent is returned (legacy behaviour)
+	wantAll := []string{"hardConsumer", "softConsumer", "orderingClient", "transitive"}
+	gotAll := a.planDependentsTopological("sink", false)
+	if !reflect.DeepEqual(sortedCopy(gotAll), sortedCopy(wantAll)) {
+		t.Errorf("non-filtered dependents of sink: got %v want %v", sortedCopy(gotAll), sortedCopy(wantAll))
+	}
+
+	// cascadingOnly=true -> orderingClient is excluded; transitive remains (hard chain)
+	wantCascade := []string{"hardConsumer", "softConsumer", "transitive"}
+	gotCascade := a.planDependentsTopological("sink", true)
+	if !reflect.DeepEqual(sortedCopy(gotCascade), sortedCopy(wantCascade)) {
+		t.Errorf("cascading dependents of sink: got %v want %v", sortedCopy(gotCascade), sortedCopy(wantCascade))
+	}
+	for _, n := range gotCascade {
+		if n == "orderingClient" {
+			t.Fatalf("orderingClient must NOT appear in cascading dependents, got %v", gotCascade)
+		}
+	}
+}
+
+func TestPlanDependentsTopological_LegacySnapshotDefaultsToHard(t *testing.T) {
+	// Simulate a snapshot written before DepTypes existed: DepTypes is nil but
+	// Deps is populated. Backward-compat requires defaulting to "hard" so every
+	// edge still cascades.
+	plan := []state.PlanComponent{
+		{Name: "sink"},
+		{Name: "consumerA", Deps: []string{"sink"}},
+		{Name: "consumerB", Deps: []string{"sink"}},
+	}
+	a := &Agent{planComps: plan}
+	got := a.planDependentsTopological("sink", true)
+	want := []string{"consumerA", "consumerB"}
+	if !reflect.DeepEqual(sortedCopy(got), sortedCopy(want)) {
+		t.Errorf("legacy snapshot cascade: got %v want %v", sortedCopy(got), sortedCopy(want))
+	}
+}
+
+func TestPlanComponentSnapshotRoundTrip(t *testing.T) {
+	original := state.PlanComponent{
+		Name:          "consumer",
+		RecipePath:    "consumer:1.0.0",
+		RecipeMeta:    "com.example.consumer",
+		RecipeVersion: "1.0.0",
+		RecipeID:      "com.example.consumer:1.0.0",
+		RecipeDigest:  "deadbeef",
+		Deps:          []string{"sink", "router"},
+		DepTypes: map[string]string{
+			"sink":   "soft",
+			"router": "ordering",
+		},
+	}
+	b, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var decoded state.PlanComponent
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if !reflect.DeepEqual(decoded, original) {
+		t.Errorf("round-trip mismatch:\n got %+v\nwant %+v", decoded, original)
+	}
+
+	// Legacy snapshot: no dep_types field at all -> decode to nil map.
+	legacy := []byte(`{"name":"old","recipe_path":"p","recipe_meta":"m","deps":["x"]}`)
+	var oldComp state.PlanComponent
+	if err := json.Unmarshal(legacy, &oldComp); err != nil {
+		t.Fatalf("legacy unmarshal failed: %v", err)
+	}
+	if oldComp.DepTypes != nil {
+		t.Errorf("legacy snapshot must decode DepTypes as nil, got %v", oldComp.DepTypes)
+	}
+}

--- a/internal/agent/handler.go
+++ b/internal/agent/handler.go
@@ -154,7 +154,7 @@ func (a *Agent) RestartComponent(name string, wait string, timeout time.Duration
 	}
 
 	// Get dependents in topological order
-	depsOrder := a.planDependentsTopological(name)
+	depsOrder := a.planDependentsTopological(name, true)
 	log.Printf("[handler] component=%s dependents=%v msg=restart: stopping dependents", name, depsOrder)
 
 	// Stop dependents first (reverse dependency order)
@@ -206,7 +206,7 @@ func (a *Agent) RestartComponent(name string, wait string, timeout time.Duration
 
 // RestartComponentDry returns the planned stop/start order without executing.
 func (a *Agent) RestartComponentDry(name string) *adapter.RestartDryResult {
-	depsOrder := a.planDependentsTopological(name)
+	depsOrder := a.planDependentsTopological(name, true)
 	startOrder := append([]string{name}, depsOrder...)
 	return &adapter.RestartDryResult{
 		StopOrder:  depsOrder,

--- a/internal/agent/plan_reconcile.go
+++ b/internal/agent/plan_reconcile.go
@@ -21,6 +21,7 @@ type plannedComponent struct {
 	recipeDigest string
 	recipeID     string
 	deps         []string
+	depTypes     map[string]string // dependent-component-name -> normalized type
 }
 
 type plannedState struct {
@@ -162,12 +163,16 @@ func (a *Agent) loadPlannedState(planPath string) (*plannedState, error) {
 
 	for name, comp := range byName {
 		for _, dep := range comp.rec.Dependencies {
+			if err := validateDepType(dep.Type); err != nil {
+				return nil, fmt.Errorf("component %s dependency %q: %w", name, dep.Name, err)
+			}
+			depType := normalizeDepType(dep.Type)
 			depCompName, ok := metaToCompName[dep.Name]
 			if !ok {
-				if isHardDependency(dep.Type) {
-					return nil, fmt.Errorf("component %s has hard dependency %q not present in plan", name, dep.Name)
+				if isPresenceMandatory(dep.Type) {
+					return nil, fmt.Errorf("component %s has mandatory (%s) dependency %q not present in plan", name, depType, dep.Name)
 				}
-				log.Printf("[agent] component=%s msg=soft dependency %q not present in plan (ignored)", name, dep.Name)
+				log.Printf("[agent] component=%s msg=optional (%s) dependency %q not present in plan (ignored)", name, depType, dep.Name)
 				continue
 			}
 			depComp := byName[depCompName]
@@ -176,13 +181,17 @@ func (a *Agent) loadPlannedState(planPath string) (*plannedState, error) {
 				return nil, fmt.Errorf("component %s dependency %q has invalid version constraint %q: %w", name, dep.Name, dep.Version, derr)
 			}
 			if !satisfied {
-				if isHardDependency(dep.Type) {
-					return nil, fmt.Errorf("component %s hard dependency %q constraint %q not satisfied by %s", name, dep.Name, dep.Version, depComp.rec.Metadata.Version)
+				if isPresenceMandatory(dep.Type) {
+					return nil, fmt.Errorf("component %s mandatory (%s) dependency %q constraint %q not satisfied by %s", name, depType, dep.Name, dep.Version, depComp.rec.Metadata.Version)
 				}
-				log.Printf("[agent] component=%s msg=soft dependency %q constraint %q not satisfied by %s (ignored)", name, dep.Name, dep.Version, depComp.rec.Metadata.Version)
+				log.Printf("[agent] component=%s msg=optional (%s) dependency %q constraint %q not satisfied by %s (ignored)", name, depType, dep.Name, dep.Version, depComp.rec.Metadata.Version)
 				continue
 			}
 			comp.deps = append(comp.deps, depCompName)
+			if comp.depTypes == nil {
+				comp.depTypes = make(map[string]string)
+			}
+			comp.depTypes[depCompName] = depType
 			edges[depCompName] = append(edges[depCompName], name)
 			indeg[name]++
 		}
@@ -198,6 +207,13 @@ func (a *Agent) loadPlannedState(planPath string) (*plannedState, error) {
 		comp := byName[it.Name]
 		deps := append([]string(nil), comp.deps...)
 		sort.Strings(deps)
+		var depTypes map[string]string
+		if len(comp.depTypes) > 0 {
+			depTypes = make(map[string]string, len(comp.depTypes))
+			for k, v := range comp.depTypes {
+				depTypes[k] = v
+			}
+		}
 		planMap = append(planMap, state.PlanComponent{
 			Name:          it.Name,
 			RecipePath:    it.RecipePath,
@@ -206,6 +222,7 @@ func (a *Agent) loadPlannedState(planPath string) (*plannedState, error) {
 			RecipeID:      comp.recipeID,
 			RecipeDigest:  comp.recipeDigest,
 			Deps:          deps,
+			DepTypes:      depTypes,
 		})
 	}
 
@@ -455,9 +472,47 @@ func parseRecipeStoreRef(ref string) (name, version string) {
 	return name, version
 }
 
-func isHardDependency(depType string) bool {
-	t := strings.ToLower(strings.TrimSpace(depType))
-	return t == "" || t == "hard"
+// normalizeDepType lowercases and trims a dependency type, defaulting the
+// empty string to "hard" for backward compatibility.
+func normalizeDepType(t string) string {
+	s := strings.ToLower(strings.TrimSpace(t))
+	if s == "" {
+		return "hard"
+	}
+	return s
+}
+
+// validateDepType rejects values outside the supported set up front so plans
+// with typos in `type` do not silently fall through to a different semantic.
+func validateDepType(t string) error {
+	switch normalizeDepType(t) {
+	case "hard", "soft", "ordering":
+		return nil
+	default:
+		return fmt.Errorf("invalid dependency type %q (allowed: hard, soft, ordering)", t)
+	}
+}
+
+// isPresenceMandatory reports whether the dependency must be present in the
+// plan for the plan to be valid. Mandatory: hard and ordering. Optional: soft.
+func isPresenceMandatory(t string) bool {
+	switch normalizeDepType(t) {
+	case "hard", "ordering":
+		return true
+	default:
+		return false
+	}
+}
+
+// shouldCascadeRestart reports whether restarting the dependency should also
+// restart the dependent. Cascading: hard and soft. Non-cascading: ordering.
+func shouldCascadeRestart(t string) bool {
+	switch normalizeDepType(t) {
+	case "hard", "soft":
+		return true
+	default:
+		return false
+	}
 }
 
 func dependencyVersionSatisfied(constraint, actual string) (bool, error) {

--- a/internal/recipe/types.go
+++ b/internal/recipe/types.go
@@ -129,8 +129,20 @@ type Resources struct {
 }
 
 // Dependency models recipe-level dependencies referencing other components by name.
+//
+// Type controls two independent semantics of the dependency:
+//
+//   - hard      (default): dependency must be present in the plan AND the
+//     dependent is restarted whenever the dependency is restarted.
+//   - soft               : dependency is optional in the plan AND the
+//     dependent is restarted whenever the dependency is restarted.
+//   - ordering           : dependency must be present in the plan but the
+//     dependent is NOT restarted when the dependency is restarted; it only
+//     governs start/stop ordering.
+//
+// An empty value is treated as "hard" for backward compatibility.
 type Dependency struct {
 	Name    string `toml:"name"`
 	Version string `toml:"version"`
-	Type    string `toml:"type"` // hard|soft (unused in MVP)
+	Type    string `toml:"type"` // hard|soft|ordering (default hard)
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -23,14 +23,20 @@ type Snapshot struct {
 }
 
 // PlanComponent persists mapping from component name to recipe and deps.
+//
+// DepTypes carries the dependency type ("hard", "soft", or "ordering") per
+// entry in Deps, keyed by the dependent plan-component name. It is optional
+// for backward compatibility: snapshots written before the field existed have
+// an empty map and consumers must default missing entries to "hard".
 type PlanComponent struct {
-	Name          string   `json:"name"`
-	RecipePath    string   `json:"recipe_path"`
-	RecipeMeta    string   `json:"recipe_meta"`
-	RecipeVersion string   `json:"recipe_version,omitempty"`
-	RecipeID      string   `json:"recipe_id,omitempty"`
-	RecipeDigest  string   `json:"recipe_digest,omitempty"`
-	Deps          []string `json:"deps"`
+	Name          string            `json:"name"`
+	RecipePath    string            `json:"recipe_path"`
+	RecipeMeta    string            `json:"recipe_meta"`
+	RecipeVersion string            `json:"recipe_version,omitempty"`
+	RecipeID      string            `json:"recipe_id,omitempty"`
+	RecipeDigest  string            `json:"recipe_digest,omitempty"`
+	Deps          []string          `json:"deps"`
+	DepTypes      map[string]string `json:"dep_types,omitempty"`
 }
 
 // Save persists the snapshot to disk atomically.


### PR DESCRIPTION
## Summary

Closes #3.

A batch of four related fixes/changes to the agent runtime, surfaced while
running a small four-component plan (process mode, `restart_policy=on-failure`)
and validated end-to-end on an Ubuntu 22.04 host. Severities range from low
(cosmetic API surface) to medium-high (silent data loss on operator-initiated
restart, and a crashed agent silently losing supervisory control).

Branch cut from `develop`; `develop` and `main` are aligned at the base commit,
so this PR contains exactly the commits below.

## What's in here

| Commit | Type | What |
|--------|------|------|
| `50186b6` | fix | `applyPlan` now mirrors plan recipes into the recipe store so `GET /v1/recipes` reflects the supervised set |
| `3cf0e01` | feat | `[[dependencies]] type` is honored at the restart cascade via three values: `hard` / `soft` / `ordering` |
| `59d1782` | fix | boot-resume **Variant A**: resume the last plan when the previous apply was interrupted (`status=applying`) |
| `7deef5d` | fix | boot-resume **Variant B**: reap init-orphan children and force a fresh restart after a crashed (SIGKILL'd) agent |
| `1ace2d7` | fix | `ApplyPlanContent` preserves `applied.toml` when a candidate plan is rejected or used for dry-run |

## Details

### 1. Mirror plan recipes into the recipe store (`50186b6`)
`applyPlan` parsed recipes but never wrote them to `a.recipes`, so `GET /v1/recipes`
returned only manually-POSTed entries. New helper `mirrorRecipeToStore(...)` writes
each plan recipe into the store with `force=true`; errors are non-fatal (logged, do
not block the install).

### 2. Dependency `type` at the restart cascade (`3cf0e01`)
The `type` field was honored only at validation and dropped from the graph, so
`RestartComponent` cascaded **every** dependent regardless of type — killing
producer-style components (e.g. a Telegraf-style agent buffering for an
InfluxDB-style sink) during a sink restart and dropping their in-memory buffer.

Split into three explicit values:

| `type`     | Presence | Cascade on restart of dep |
|------------|----------|----------------------------|
| `hard`     | required | yes                        |
| `soft`     | optional | yes                        |
| `ordering` | required | **no**                     |

Empty `type` keeps mapping to `hard`; existing plans are byte-identical. `DepTypes`
is persisted per-edge in `state.PlanComponent` (`omitempty`, legacy snapshots decode
to `nil` and default to `hard`). Unknown values are now rejected up front instead of
silently behaving like `soft`.

### 3. Boot-resume Variant A (`59d1782`)
The resume condition only fired on `status` in {`running`, `failed`}. An apply
interrupted mid-flight left `status=applying`, so the agent came up healthy
(`/healthz` 200, `active running`) but supervised nothing. Replaced with
`shouldResumeLastPlan(status)` — resumes for everything except `stopped` and
`dry-run` — and logs a recovery line when recovering from `applying`.

### 4. Boot-resume Variant B (`7deef5d`)
After a SIGKILL/OOM/segfault, children are reparented to PID 1 but keep running;
the next boot loaded their persisted `state=running`, reconcile marked them
`no_touch`, the supervisor logged "all components running" — yet the agent had no
handles to them (so `/v1/components` showed `state=stopped`, `restart_policy` could
not fire, `keystonectl stop` was a no-op). Two changes on the resume path:
`reapOrphanedComponents` signals PIDs whose `/proc/<pid>/status` shows `PPid: 1`
(SIGTERM then SIGKILL; the `PPid==1` guard avoids killing a reused PID), and the
persisted component state is reset before reconcile reads it so the plan re-applies
from scratch.

### 5. Preserve `applied.toml` on rejection/dry-run (`1ace2d7`)
`ApplyPlanContent` wrote the candidate to the canonical `applied.toml` *before*
validation, so a rejected plan corrupted it — breaking the internal rollback (which
reads `oldPlanPath = a.planPath`) and the next boot resume. Now staged to
`applied.toml.staging`, promoted via `os.Rename` only on a successful real apply, and
discarded on dry-run/failure.

## Testing

- **Unit tests** (all green): `internal/agent` gains coverage for the recipe mirror,
  the four dependency-type helpers, the cascade filter (incl. a transitive hard chain
  and legacy-snapshot back-compat), a `PlanComponent` snapshot round-trip, the resume
  decision truth table, and the orphan-reap helpers (`processExists`,
  `processIsInitOrphan`, `reapOrphanedComponents` no-op cases).
- **End-to-end** on Ubuntu 22.04 with a 4-component plan (sink + hard/soft/ordering
  dependents):
  - Task 1: `/v1/recipes` returns all four recipes (was `[]`).
  - Task 2: `restart sink` leaves the `ordering` dependent's PID unchanged while
    `hard`/`soft` rotate; dry-run preview matches; `type="whenever"` is rejected.
  - Task 3 A: snapshot forced to `applying` — `develop` skips resume, this branch
    recovers and brings all components to `running`.
  - Task 3 B: `kill -9` the agent — `develop` leaves orphans reported as `stopped`
    with `no_touch=[all]`; this branch reaps the orphans, reconciles with
    `start_order=[all]`/`no_touch=[]`, and restarts everything under new PIDs.
  - Task 4: applying a rejected plan leaves `applied.toml` byte-identical and the
    running plan untouched.

## Backward compatibility

- Recipes without `type` behave exactly as before (`hard`).
- Snapshots written by older agents (no `dep_types`) load unchanged and default each
  edge to `hard`.
- No API shape changes; `GET /v1/recipes` simply stops being empty for plan-driven
  deployments.
