### PR TITLE
chore: gitignore .tmuxp.yaml + stdlib lint cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ runtime
 
 #OS Files
 .DS_Store
+
+# tmux session layout (local dev convenience)
+.tmuxp.yaml

--- a/internal/runner/containerrunner.go
+++ b/internal/runner/containerrunner.go
@@ -150,7 +150,7 @@ func NewContainerRunner(cfg ContainerRunnerConfig) (*ContainerRunner, error) {
 	if pluginDirs == "" {
 		r.cniPluginDir = []string{"/opt/cni/bin", "/usr/lib/cni"}
 	} else {
-		for _, p := range strings.Split(pluginDirs, ":") {
+		for p := range strings.SplitSeq(pluginDirs, ":") {
 			p = strings.TrimSpace(p)
 			if p != "" {
 				r.cniPluginDir = append(r.cniPluginDir, p)

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"maps"
 	"os"
 	"sync"
 	"time"
@@ -195,9 +196,7 @@ func BuildGraph(comps []*Component) *Graph {
 // TopoLayers returns ordered layers where each layer can start in parallel.
 func (g *Graph) TopoLayers() ([][]string, error) {
 	in := make(map[string]int, len(g.InDeg))
-	for k, v := range g.InDeg {
-		in[k] = v
-	}
+	maps.Copy(in, g.InDeg)
 	var q []string
 	for n, d := range in {
 		if d == 0 {


### PR DESCRIPTION
## Summary

Housekeeping after the CI workflow landed.

- **gitignore** the local `.tmuxp.yaml` tmux session layout so it stops showing as untracked.
- **supervisor** — replace the manual `for k,v := range … { in[k]=v }` copy with `maps.Copy` (Go 1.21+).
- **runner** — range over `strings.SplitSeq` instead of `strings.Split` (Go 1.24+ iterator, no intermediate slice).

No behavioural change. `go build`/`go vet`/`gofmt`/`go test -race` all clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)