### PR TITLE
feat(mqtt): accept inline recipes in cmd/apply

### DIFF
--- a/internal/adapter/mqtt/messages.go
+++ b/internal/adapter/mqtt/messages.go
@@ -22,6 +22,13 @@ type ApplyRequest struct {
 	// Used when PlanPath is empty.
 	Content string `json:"content,omitempty"`
 
+	// Recipes are recipe TOML documents to store (add-recipe with force) BEFORE
+	// the plan is reconciled, in the same apply. This lets a controller ship a
+	// plan and the recipes it references atomically in one message, removing the
+	// add-recipe→apply ordering race (no need for a separate cmd/add-recipe or a
+	// sleep between the two). Empty = apply expects the recipes to already exist.
+	Recipes []string `json:"recipes,omitempty"`
+
 	// Dry indicates a dry-run (no actual execution).
 	Dry bool `json:"dry,omitempty"`
 }

--- a/internal/adapter/mqtt/mqtt.go
+++ b/internal/adapter/mqtt/mqtt.go
@@ -309,7 +309,17 @@ func (a *Adapter) handleApply(client pahomqtt.Client, msg pahomqtt.Message) {
 		return
 	}
 
-	log.Printf("[mqtt] cmd/apply planPath=%s dry=%v", req.PlanPath, req.Dry)
+	log.Printf("[mqtt] cmd/apply planPath=%s recipes=%d dry=%v", req.PlanPath, len(req.Recipes), req.Dry)
+
+	// Store any inline recipes BEFORE reconciling the plan, so a plan and the
+	// recipes it references arrive atomically in one apply (no add-recipe→apply
+	// race). force=true: the controller is the source of truth for the version.
+	for i, rec := range req.Recipes {
+		if _, _, rerr := a.handler.AddRecipe(rec, true); rerr != nil {
+			a.respond(a.topics.RespApply, req.CorrelationID, NewErrorResponse(req.CorrelationID, fmt.Errorf("inline recipe %d: %w", i, rerr)))
+			return
+		}
+	}
 
 	var err error
 	if req.PlanPath != "" {


### PR DESCRIPTION
Lets a controller ship a plan and the recipes it references **atomically in one apply message**, removing the add-recipe→apply ordering race (and the sleep hedge a controller otherwise needs between the two commands).

## Cambios
- `ApplyRequest.Recipes []string` (MQTT adapter).
- `handleApply` guarda cada receta (`AddRecipe`, force) **antes** de reconciliar el plan.
- `Recipes` vacío = comportamiento previo intacto.

## Contexto
Contrapartida del control plane OTA de WolfOps (plan 27): el script de campaña publica un único `cmd/apply` con `{content: plan, recipes: [recipe]}`. Verificado end-to-end con 8 agentes reales convergiendo.

Build + tests del adaptador MQTT en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)