### PR TITLE
fix(agent): never report or reuse a dead component as running

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ All agent flags are discoverable via `./keystone --help`. Environment variables 
 
 - `README.md` — Features, quick start, all CLI flags, environment variables
 - `docs/security.md` — Security model: secure-by-default posture, auth, signing, `--insecure-skip-verify`, config reference
+- `docs/component-state.md` — Component states, liveness guarantees of `/v1/components`, reuse rules on re-apply
 - `docs/adapters.md` — Adapter comparison, HTTP auth, NATS/MQTT configuration details
 - `docs/containers.md` — Container recipe syntax and examples
 - `docs/containerrunner-design.md` — Containerd integration design decisions

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Why Keystone? Because edge fleets need something that is lightweight, predictabl
 | Document | What it covers |
 |----------|----------------|
 | [docs/security.md](docs/security.md) | **Security model**: threat model, secure-by-default controls, auth, signing, the `--insecure-skip-verify` escape hatch, config reference |
+| [docs/component-state.md](docs/component-state.md) | Component states, liveness guarantees of `GET /v1/components`, and when a re-apply reuses a running component |
 | [docs/adapters.md](docs/adapters.md) | Control-plane adapters: HTTP (auth), NATS (+ JetStream), MQTT — comparison and configuration |
 | [docs/containers.md](docs/containers.md) | Container recipe syntax and examples |
 | [docs/containerrunner-design.md](docs/containerrunner-design.md) | containerd integration design notes |

--- a/docs/component-state.md
+++ b/docs/component-state.md
@@ -1,0 +1,76 @@
+# Component State and Reuse
+
+`GET /v1/components` is meant to be trustworthy enough to alert on. This
+document states what each component state means, what the agent guarantees
+about it, and when a re-apply keeps a component running instead of restarting
+it.
+
+## States
+
+| State | Meaning |
+|-------|---------|
+| `none` | Known from the plan, nothing installed or started yet |
+| `installing` | Install hook / artifact download in progress |
+| `stopped` | Not running. Either never started, stopped on request, or exited on its own with code 0 and no restart policy that applies |
+| `running` | A managed instance is alive and supervised |
+| `failed` | Terminal failure: crashed with no applicable restart policy, or exhausted `max_retries` |
+| `stopping` | Stop in progress |
+
+`last_health` is `healthy` / `unhealthy` / `unknown`. Only components that
+declare `[lifecycle.run.health]` ever get a verdict; the rest stay `unknown`
+forever, and that is not a problem.
+
+## Liveness guarantees
+
+- A component reported `running` has a live supervision loop attached: its
+  health probe and restart policy are active.
+- A component reported `running` with `pid > 0` has that PID alive. The agent
+  never advertises a PID that no longer exists — when a process is gone, the
+  PID is cleared to `0` and the state moves to `stopped` or `failed`.
+- Every exit the runner will not retry updates the state, including a clean
+  exit with code 0. A process that traps `SIGTERM` and shuts down gracefully
+  under `restart_policy = "on-failure"` is reported `stopped`, not left at its
+  last known good state.
+- `last_health` is reset to `unknown` when a component exits: a component that
+  is gone cannot still be healthy.
+
+Container components report `pid = 0` (there is no host PID to probe), so for
+those the supervision loop is the only liveness signal.
+
+## Reuse on re-apply
+
+Applying a plan is a reconcile, not a restart: components whose recipe identity
+and digest are unchanged are candidates to be kept running as-is (they show up
+as `no_touch` in the reconcile log). Keeping one is only safe when there is
+something watching it, because a reused component gets no new supervision loop
+— whatever restart policy and health probe it has must already be attached.
+
+So a component is reused only when all of these hold:
+
+1. it is reported `running`;
+2. it has a live supervision loop;
+3. its process is alive (when it runs as a process); and
+4. it is reported `healthy`, if it declares a health check.
+
+Otherwise the agent tears down what is left of the previous instance and starts
+a fresh one. The decision is taken twice — when the reconcile is planned and
+again immediately before the stack starts — because a component can die in
+between; the log records the outcome:
+
+```
+[agent] component=api msg=reusing existing running instance (no restart)
+[agent] component=api msg=reuse revoked, starting a fresh instance
+```
+
+Reuse is never assumed from cached state alone. Cached state records the last
+observed transition, and a component can read `running/healthy` while its
+process is already gone; adopting one of those would freeze the API on a lie
+and leave the component unsupervised (see issue #10).
+
+## Recovery after an agent crash
+
+If the agent itself is killed (SIGKILL, OOM, segfault), its children are
+reparented to init and survive with no supervisor. On the next boot the agent
+reaps any orphan recorded in its snapshot, resets the persisted component
+states, and re-applies the last plan from scratch. Persisted `running` states
+are informational after a crash, never authoritative.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -51,6 +51,11 @@ type Agent struct {
 	handles         map[string]runner.Handle // Process or container handles
 	runners         map[string]runner.Runner // Runner instances (for containers that need cleanup)
 	cancels         map[string]context.CancelFunc
+	// supervised tracks components with a live RunManaged loop attached. A
+	// component missing from this map is not being watched by anybody: its
+	// health probe and restart policy are gone even if the process happens to
+	// be alive, so a reconcile must never adopt it as "running".
+	supervised map[string]bool
 	// applySkipStart marks components that should be kept running as-is during
 	// the current reconcile apply pass.
 	applySkipStart map[string]bool
@@ -94,6 +99,7 @@ func New(opts Options) *Agent {
 		handles:        make(map[string]runner.Handle),
 		runners:        make(map[string]runner.Runner),
 		cancels:        make(map[string]context.CancelFunc),
+		supervised:     make(map[string]bool),
 		applySkipStart: make(map[string]bool),
 		stateDir:       filepath.Join("runtime", "state"),
 		ctx:            ctx,
@@ -368,6 +374,18 @@ func (a *Agent) applyPlan(planPath string) error {
 	// readiness channels per component (closed when process/container actually starts)
 	compReady := make(map[string]chan struct{})
 	compStartErr := make(map[string]chan error)
+	// Components reconcile decided to keep running as-is. Reconcile decided
+	// from cached state, so each one is re-checked against real liveness once
+	// the whole plan is built (see "Confirm every reuse decision" below);
+	// skipStart points at the flag the lifecycle hooks read, so a revoked
+	// decision turns into a normal install+start.
+	type reuseCandidate struct {
+		name          string
+		comp          *supervisor.Component
+		requireHealth bool
+		skipStart     *bool
+	}
+	var reuseCandidates []reuseCandidate
 	for _, l := range loadedList {
 		// find deps for this comp
 		var depNames []string
@@ -521,7 +539,11 @@ func (a *Agent) applyPlan(planPath string) error {
 				ctx2, cancel := context.WithCancel(ctx)
 				a.mu.Lock()
 				a.cancels[it.Name] = cancel
+				a.supervised[it.Name] = true
 				a.mu.Unlock()
+				// Once RunManaged returns, this component has no health loop
+				// and no restart policy attached any more.
+				defer a.clearSupervised(it.Name)
 
 				_ = compRunner.RunManaged(ctx2, it.Name, opts, hc, rp, maxRetries,
 					func(h runner.Handle) {
@@ -574,23 +596,16 @@ func (a *Agent) applyPlan(planPath string) error {
 						}
 					},
 					func(err error) {
-						if err != nil {
-							log.Printf("[agent] component=%s terminal failure: %v", it.Name, err)
-							signalStartErr(err)
-							a.mu.Lock()
-							ci, ok := a.comps.Get(it.Name)
-							if ok {
-								ci.State = "failed"
-								a.comps.Upsert(ci)
-							}
-							delete(a.handles, it.Name)
-							// Release runner resources for terminal components.
-							if runnerCleanup != nil {
-								runnerCleanup()
-								delete(a.runners, it.Name)
-							}
-							a.mu.Unlock()
+						// An exit the runner will not retry is a startup
+						// failure too when readiness was never reached, even
+						// if the exit code was 0. signalStartErr is a no-op
+						// once the component signalled ready.
+						startErr := err
+						if startErr == nil {
+							startErr = fmt.Errorf("process exited cleanly before becoming ready")
 						}
+						signalStartErr(startErr)
+						a.handleComponentExit(it.Name, err, runnerCleanup)
 					},
 				)
 			}()
@@ -627,8 +642,15 @@ func (a *Agent) applyPlan(planPath string) error {
 		startErrCh := make(chan error, 1)
 		c := supervisor.NewComponent(it.Name, depNames, installFn, startFn, stopFn)
 		if skipStart {
-			c.MarkRunningForReuse()
-			log.Printf("[agent] component=%s msg=reusing existing running instance (no restart)", it.Name)
+			// Deliberately not marked as running yet: the install/start hooks
+			// above read skipStart when StartStack runs, so the decision can
+			// still be revoked below if the component turns out to be dead.
+			reuseCandidates = append(reuseCandidates, reuseCandidate{
+				name:          it.Name,
+				comp:          c,
+				requireHealth: reuseRequiresHealth(r),
+				skipStart:     &skipStart,
+			})
 		}
 		c.ReadyCh = readyCh
 		c.ReadyErrCh = startErrCh
@@ -662,14 +684,41 @@ func (a *Agent) applyPlan(planPath string) error {
 		return nil
 	}
 
+	// Confirm every reuse decision as late as possible, before any state is
+	// rewritten below. Reconcile classified these components from cached
+	// state; if one has died since (or lost its supervision loop), adopting it
+	// would advertise it as running with nobody watching it.
+	reused := make(map[string]bool, len(reuseCandidates))
+	for _, rc := range reuseCandidates {
+		if a.componentIsReusable(rc.name, rc.requireHealth) {
+			rc.comp.MarkRunningForReuse()
+			reused[rc.name] = true
+			log.Printf("[agent] component=%s msg=reusing existing running instance (no restart)", rc.name)
+			continue
+		}
+		log.Printf("[agent] component=%s msg=reuse revoked, starting a fresh instance", rc.name)
+		// Tear down whatever is left of the previous instance (managed loop,
+		// handle, surviving process) before starting a new one: otherwise the
+		// old loop treats the takeover as a failure and both loops end up
+		// restarting the same component against each other.
+		a.stopComponent(rc.name)
+		*rc.skipStart = false
+	}
+
 	// Update store initially with recipe/version metadata for API visibility.
 	for _, l := range loadedList {
-		a.comps.Upsert(store.ComponentInfo{
+		ci := store.ComponentInfo{
 			Name:    l.item.Name,
 			State:   string(supervisor.StateNone),
 			Recipe:  l.item.RecipePath,
 			Version: l.rec.Metadata.Version,
-		})
+		}
+		if reused[l.item.Name] {
+			// Confirmed running and kept as-is: an empty state tells Upsert to
+			// preserve it instead of reporting the component back to "none".
+			ci.State = ""
+		}
+		a.comps.Upsert(ci)
 	}
 	// Poll states to store and component-state metric
 	go func() {
@@ -684,7 +733,10 @@ func (a *Agent) applyPlan(planPath string) error {
 				a.mu.RLock()
 				_, running := a.handles[c.Name]
 				a.mu.RUnlock()
-				ci, _ := a.comps.Get(c.Name)
+				ci, known := a.comps.Get(c.Name)
+				if !known {
+					continue
+				}
 
 				// Keep "failed" state if it was set by terminal error
 				st := ci.State
@@ -693,7 +745,15 @@ func (a *Agent) applyPlan(planPath string) error {
 					if running {
 						st = "running"
 					}
-					a.comps.Upsert(store.ComponentInfo{Name: c.Name, State: st})
+					ci.State = st
+					// Never keep advertising a PID that is gone: with no
+					// managed handle and no live process, the recorded PID
+					// belongs to nothing (and may already be recycled).
+					if ci.PID > 0 && !running && !sysrt.IsProcessRunning(ci.PID) {
+						ci.PID = 0
+						ci.LastHealth = "unknown"
+					}
+					a.comps.Replace(ci)
 				}
 
 				metrics.ObserveComponentState(c.Name, st)
@@ -1199,10 +1259,12 @@ func (a *Agent) restartFromPlan(name string) error {
 		ctx2, cancel := context.WithCancel(a.Context())
 		a.mu.Lock()
 		a.cancels[name] = cancel
+		a.supervised[name] = true
 		if compRunner != nil {
 			a.runners[name] = compRunner
 		}
 		a.mu.Unlock()
+		defer a.clearSupervised(name)
 
 		_ = compRunner.RunManaged(ctx2, name, opts, hc, rp, maxRetries,
 			func(h runner.Handle) {
@@ -1244,21 +1306,7 @@ func (a *Agent) restartFromPlan(name string) error {
 				metrics.SetHealthy(name, ok)
 			},
 			func(err error) {
-				if err != nil {
-					log.Printf("[agent] component=%s terminal failure on restart: %v", name, err)
-					a.mu.Lock()
-					ci, ok := a.comps.Get(name)
-					if ok {
-						ci.State = "failed"
-						a.comps.Upsert(ci)
-					}
-					delete(a.handles, name)
-					if runnerCleanup != nil {
-						runnerCleanup()
-						delete(a.runners, name)
-					}
-					a.mu.Unlock()
-				}
+				a.handleComponentExit(name, err, runnerCleanup)
 			},
 		)
 		// Enforce artifact cache budget after (re)start
@@ -1267,12 +1315,72 @@ func (a *Agent) restartFromPlan(name string) error {
 	return nil
 }
 
+// markSupervised records that a RunManaged loop is now attached to name.
+func (a *Agent) markSupervised(name string) {
+	a.mu.Lock()
+	a.supervised[name] = true
+	a.mu.Unlock()
+}
+
+// clearSupervised records that the RunManaged loop for name has returned, so
+// nothing is watching the component any more.
+func (a *Agent) clearSupervised(name string) {
+	a.mu.Lock()
+	delete(a.supervised, name)
+	a.mu.Unlock()
+}
+
+// isSupervised reports whether a RunManaged loop is currently attached to name.
+func (a *Agent) isSupervised(name string) bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.supervised[name]
+}
+
+// handleComponentExit records in the component store a terminal exit that the
+// runner will not restart, and releases the resources tied to that instance.
+//
+// It runs for every such exit, not only for failures: a process that exits 0
+// under restart_policy="on-failure" is just as gone as one that crashed. If
+// only the error path updated the store, a clean exit would leave the
+// component reported running/healthy with a dead PID forever — a lie for
+// GET /v1/components and bait for a later reconcile looking for components to
+// reuse.
+func (a *Agent) handleComponentExit(name string, exitErr error, runnerCleanup func()) {
+	newState := "stopped"
+	if exitErr != nil {
+		newState = "failed"
+		log.Printf("[agent] component=%s terminal failure: %v", name, exitErr)
+	} else {
+		log.Printf("[agent] component=%s msg=exited cleanly and will not be restarted (state=stopped)", name)
+	}
+	a.mu.Lock()
+	if ci, ok := a.comps.Get(name); ok {
+		ci.State = newState
+		ci.PID = 0
+		ci.LastHealth = "unknown"
+		// Replace, not Upsert: Upsert would read PID 0 as "keep the old PID".
+		a.comps.Replace(ci)
+	}
+	delete(a.handles, name)
+	// Release runner resources for terminal components.
+	if runnerCleanup != nil {
+		runnerCleanup()
+		delete(a.runners, name)
+	}
+	a.mu.Unlock()
+	metrics.SetHealthy(name, false)
+}
+
 // stopComponent cancels managed loop and stops process/container, updating store.
 func (a *Agent) stopComponent(name string) {
 	log.Printf("agent: stopComponent start name=%s", name)
 	// Grab references under lock, but perform blocking ops outside the lock
 	a.mu.Lock()
 	cancel := a.cancels[name]
+	// Drop the supervision marker up front: the managed loop is about to be
+	// cancelled, and until it returns nothing is watching this component.
+	delete(a.supervised, name)
 	var h runner.Handle
 	var compRunner runner.Runner
 	if cancel != nil {
@@ -1330,7 +1438,14 @@ func (a *Agent) stopComponent(name string) {
 		ci = store.ComponentInfo{Name: name}
 	}
 	ci.State = "stopped"
-	a.comps.Upsert(ci)
+	ci.LastHealth = "unknown"
+	// Keep the PID only while the process is somehow still around, so a stop
+	// that did not fully take effect can still be reaped later; otherwise stop
+	// advertising a PID that no longer exists.
+	if ci.PID > 0 && !sysrt.IsProcessRunning(ci.PID) {
+		ci.PID = 0
+	}
+	a.comps.Replace(ci)
 	// Best-effort lifecycle shutdown hook for this component.
 	shCtx, shCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	if err := a.runComponentShutdownScript(shCtx, name); err != nil {

--- a/internal/agent/plan_reconcile.go
+++ b/internal/agent/plan_reconcile.go
@@ -12,6 +12,7 @@ import (
 	semver "github.com/Masterminds/semver/v3"
 	"github.com/carlosprados/keystone/internal/deploy"
 	"github.com/carlosprados/keystone/internal/recipe"
+	sysrt "github.com/carlosprados/keystone/internal/runtime"
 	"github.com/carlosprados/keystone/internal/state"
 )
 
@@ -297,11 +298,10 @@ func (a *Agent) buildReconcileActions(oldPlan []state.PlanComponent, desired *pl
 		}
 	}
 
-	// Components left untouched must currently satisfy readiness.
+	// Components left untouched must currently be alive and supervised.
 	for name := range noTouch {
 		comp := desired.byName[name]
-		requireHealth := strings.TrimSpace(comp.rec.Lifecycle.Run.Health.Check) != ""
-		if a.componentIsReady(name, requireHealth) {
+		if a.componentIsReusable(name, reuseRequiresHealth(comp.rec)) {
 			continue
 		}
 		startTargets[name] = true
@@ -420,7 +420,30 @@ func (a *Agent) componentChanged(old state.PlanComponent, desired *plannedCompon
 	return oldDigest != newDigest
 }
 
-func (a *Agent) componentIsReady(name string, requireHealth bool) bool {
+// reuseRequiresHealth reports whether reusing a component must also see it
+// reported healthy: only components that declare a health check ever get a
+// health verdict, so requiring one from the rest would restart them forever.
+func reuseRequiresHealth(r *recipe.Recipe) bool {
+	return strings.TrimSpace(r.Lifecycle.Run.Health.Check) != ""
+}
+
+// componentIsReusable reports whether the component named name can be kept
+// running as-is across a reconcile (classified no_touch) instead of being
+// restarted.
+//
+// The cached state in a.comps is not enough on its own: it records the last
+// observed transition, so a component can read running/healthy while the
+// process is already gone. Adopting one of those freezes the API on a lie and
+// leaves the component with nobody watching it, because a reused component
+// gets no new RunManaged call — whatever health probe and restart policy it
+// has must already be attached. Hence reuse additionally requires:
+//
+//   - a live supervision loop for it, and
+//   - a live OS process, when the component runs as a process (PID > 0).
+//
+// Container components report PID 0 and cannot be probed by PID here; for
+// those the supervision-loop check is the only liveness signal.
+func (a *Agent) componentIsReusable(name string, requireHealth bool) bool {
 	ci, ok := a.comps.Get(name)
 	if !ok {
 		return false
@@ -428,8 +451,16 @@ func (a *Agent) componentIsReady(name string, requireHealth bool) bool {
 	if ci.State != "running" {
 		return false
 	}
-	if requireHealth {
-		return ci.LastHealth == "healthy"
+	if requireHealth && ci.LastHealth != "healthy" {
+		return false
+	}
+	if !a.isSupervised(name) {
+		log.Printf("[agent] component=%s msg=state reads running but no supervision loop is attached; will restart instead of reusing", name)
+		return false
+	}
+	if ci.PID > 0 && !sysrt.IsProcessRunning(ci.PID) {
+		log.Printf("[agent] component=%s pid=%d msg=state reads running but the process is gone; will restart instead of reusing", name, ci.PID)
+		return false
 	}
 	return true
 }

--- a/internal/agent/stale_state_test.go
+++ b/internal/agent/stale_state_test.go
@@ -1,0 +1,293 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/carlosprados/keystone/internal/deploy"
+	"github.com/carlosprados/keystone/internal/recipe"
+	"github.com/carlosprados/keystone/internal/runner"
+	"github.com/carlosprados/keystone/internal/state"
+	"github.com/carlosprados/keystone/internal/store"
+)
+
+// deadPID is well above PID_MAX on Linux (4194303 by default), so no process
+// can ever own it.
+const deadPID = 99999999
+
+func newStateAgent() *Agent {
+	return &Agent{
+		comps:          store.NewMemoryStore(),
+		supervised:     make(map[string]bool),
+		handles:        make(map[string]runner.Handle),
+		runners:        make(map[string]runner.Runner),
+		cancels:        make(map[string]context.CancelFunc),
+		applySkipStart: make(map[string]bool),
+	}
+}
+
+func TestComponentIsReusable(t *testing.T) {
+	cases := []struct {
+		name          string
+		ci            *store.ComponentInfo // nil = component unknown to the store
+		supervised    bool
+		requireHealth bool
+		want          bool
+		reason        string
+	}{
+		{
+			name:   "unknown component",
+			want:   false,
+			reason: "nothing is known about it, so it cannot be adopted",
+		},
+		{
+			name:       "live process, supervised",
+			ci:         &store.ComponentInfo{Name: "c", State: "running", LastHealth: "healthy", PID: os.Getpid()},
+			supervised: true,
+			want:       true,
+			reason:     "alive and watched: the only case where reuse is safe",
+		},
+		{
+			name:       "dead PID, supervised",
+			ci:         &store.ComponentInfo{Name: "c", State: "running", LastHealth: "healthy", PID: deadPID},
+			supervised: true,
+			want:       false,
+			reason:     "the reported PID does not exist: cached state is stale",
+		},
+		{
+			name:       "live process, not supervised",
+			ci:         &store.ComponentInfo{Name: "c", State: "running", LastHealth: "healthy", PID: os.Getpid()},
+			supervised: false,
+			want:       false,
+			reason:     "no managed loop: no health probe and no restart policy attached",
+		},
+		{
+			name:       "container-like component (no PID), supervised",
+			ci:         &store.ComponentInfo{Name: "c", State: "running", LastHealth: "healthy", PID: 0},
+			supervised: true,
+			want:       true,
+			reason:     "PID 0 cannot be probed; the supervision loop is the liveness signal",
+		},
+		{
+			name:       "state not running",
+			ci:         &store.ComponentInfo{Name: "c", State: "failed", LastHealth: "healthy", PID: os.Getpid()},
+			supervised: true,
+			want:       false,
+			reason:     "only components reported running are reuse candidates",
+		},
+		{
+			name:          "health required but unhealthy",
+			ci:            &store.ComponentInfo{Name: "c", State: "running", LastHealth: "unhealthy", PID: os.Getpid()},
+			supervised:    true,
+			requireHealth: true,
+			want:          false,
+			reason:        "a component with a health check must be healthy to be reused",
+		},
+		{
+			name:          "health required but unknown",
+			ci:            &store.ComponentInfo{Name: "c", State: "running", LastHealth: "unknown", PID: os.Getpid()},
+			supervised:    true,
+			requireHealth: true,
+			want:          false,
+			reason:        "no health verdict yet is not the same as healthy",
+		},
+		{
+			name:          "health not required, never probed",
+			ci:            &store.ComponentInfo{Name: "c", State: "running", LastHealth: "unknown", PID: os.Getpid()},
+			supervised:    true,
+			requireHealth: false,
+			want:          true,
+			reason:        "components without a health check never get a verdict",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			a := newStateAgent()
+			if c.ci != nil {
+				a.comps.Upsert(*c.ci)
+			}
+			if c.supervised {
+				a.markSupervised("c")
+			}
+			if got := a.componentIsReusable("c", c.requireHealth); got != c.want {
+				t.Errorf("componentIsReusable()=%v, want %v (%s)", got, c.want, c.reason)
+			}
+		})
+	}
+}
+
+// TestReconcileRestartsDeadNoTouchComponent covers the production incident: an
+// unchanged component whose process is gone must be restarted by the reconcile,
+// not classified as no_touch on the strength of a stale running/healthy record.
+func TestReconcileRestartsDeadNoTouchComponent(t *testing.T) {
+	planned, oldPlan := singleComponentPlan("api", "curl -sf http://127.0.0.1:8080/healthz")
+
+	t.Run("dead process is restarted", func(t *testing.T) {
+		a := newStateAgent()
+		a.comps.Upsert(store.ComponentInfo{Name: "api", State: "running", LastHealth: "healthy", PID: deadPID})
+		a.markSupervised("api")
+
+		actions, err := a.buildReconcileActions(oldPlan, planned)
+		if err != nil {
+			t.Fatalf("buildReconcileActions: %v", err)
+		}
+		if !actions.startTargets["api"] {
+			t.Errorf("api not in startTargets; a dead component must be restarted")
+		}
+		if actions.noTouch["api"] {
+			t.Errorf("api classified as no_touch; its process does not exist")
+		}
+	})
+
+	t.Run("live supervised process is reused", func(t *testing.T) {
+		a := newStateAgent()
+		a.comps.Upsert(store.ComponentInfo{Name: "api", State: "running", LastHealth: "healthy", PID: os.Getpid()})
+		a.markSupervised("api")
+
+		actions, err := a.buildReconcileActions(oldPlan, planned)
+		if err != nil {
+			t.Fatalf("buildReconcileActions: %v", err)
+		}
+		if !actions.noTouch["api"] {
+			t.Errorf("api not in no_touch; an alive supervised component must not be restarted")
+		}
+		if actions.startTargets["api"] {
+			t.Errorf("api in startTargets; nothing changed and it is alive")
+		}
+	})
+
+	t.Run("unsupervised process is restarted", func(t *testing.T) {
+		a := newStateAgent()
+		a.comps.Upsert(store.ComponentInfo{Name: "api", State: "running", LastHealth: "healthy", PID: os.Getpid()})
+		// No markSupervised: the managed loop already returned.
+
+		actions, err := a.buildReconcileActions(oldPlan, planned)
+		if err != nil {
+			t.Fatalf("buildReconcileActions: %v", err)
+		}
+		if !actions.startTargets["api"] {
+			t.Errorf("api not in startTargets; a component nobody supervises must be restarted")
+		}
+	})
+}
+
+// TestHandleComponentExit_CleanExit is the clean-exit manifestation: a process
+// that exits 0 under restart_policy="on-failure" is not restarted, and the
+// component store must say so instead of keeping the last known good state.
+func TestHandleComponentExit_CleanExit(t *testing.T) {
+	a := newStateAgent()
+	a.comps.Upsert(store.ComponentInfo{
+		Name: "border", State: "running", LastHealth: "healthy", PID: 181279, Restarts: 2,
+		Recipe: "recipes/border.toml", Version: "1.4.0",
+	})
+	a.handles["border"] = &runner.ProcessHandle{}
+	cleaned := false
+
+	a.handleComponentExit("border", nil, func() { cleaned = true })
+
+	ci, ok := a.comps.Get("border")
+	if !ok {
+		t.Fatal("component vanished from the store")
+	}
+	if ci.State != "stopped" {
+		t.Errorf("State=%q, want %q: a clean exit that is not restarted leaves the component stopped", ci.State, "stopped")
+	}
+	if ci.PID != 0 {
+		t.Errorf("PID=%d, want 0: the process is gone", ci.PID)
+	}
+	if ci.LastHealth == "healthy" {
+		t.Errorf("LastHealth=%q: a component that exited cannot still be healthy", ci.LastHealth)
+	}
+	if _, stillThere := a.handles["border"]; stillThere {
+		t.Errorf("handle still registered for an exited component")
+	}
+	if !cleaned {
+		t.Errorf("runner cleanup was not invoked")
+	}
+	// Fields the exit says nothing about must survive.
+	if ci.Restarts != 2 || ci.Recipe != "recipes/border.toml" || ci.Version != "1.4.0" {
+		t.Errorf("unrelated fields were clobbered: %+v", ci)
+	}
+}
+
+func TestHandleComponentExit_Failure(t *testing.T) {
+	a := newStateAgent()
+	a.comps.Upsert(store.ComponentInfo{Name: "influxdb", State: "running", LastHealth: "healthy", PID: 180072})
+	a.handles["influxdb"] = &runner.ProcessHandle{}
+
+	a.handleComponentExit("influxdb", errors.New("signal: killed"), nil)
+
+	ci, _ := a.comps.Get("influxdb")
+	if ci.State != "failed" {
+		t.Errorf("State=%q, want %q", ci.State, "failed")
+	}
+	if ci.PID != 0 {
+		t.Errorf("PID=%d, want 0: the process is gone", ci.PID)
+	}
+}
+
+// TestHandleComponentExit_EndsSupervision guards the invariant reuse depends
+// on: once the managed loop is gone the component must stop looking reusable.
+func TestHandleComponentExit_EndsSupervision(t *testing.T) {
+	a := newStateAgent()
+	a.comps.Upsert(store.ComponentInfo{Name: "c", State: "running", LastHealth: "healthy", PID: os.Getpid()})
+	a.markSupervised("c")
+	if !a.componentIsReusable("c", false) {
+		t.Fatal("precondition: an alive supervised component must be reusable")
+	}
+
+	a.handleComponentExit("c", nil, nil)
+	a.clearSupervised("c") // what the deferred call in the managed goroutine does
+
+	if a.componentIsReusable("c", false) {
+		t.Errorf("component still reusable after its managed loop exited")
+	}
+}
+
+func TestMemoryStoreReplaceClearsPID(t *testing.T) {
+	s := store.NewMemoryStore()
+	s.Upsert(store.ComponentInfo{Name: "c", State: "running", PID: 4242, LastHealth: "healthy"})
+
+	// Upsert cannot clear a PID: 0 means "keep the previous value".
+	s.Upsert(store.ComponentInfo{Name: "c", State: "stopped", PID: 0})
+	if ci, _ := s.Get("c"); ci.PID != 4242 {
+		t.Errorf("Upsert changed the PID to %d; its merge semantics must keep it", ci.PID)
+	}
+
+	s.Replace(store.ComponentInfo{Name: "c", State: "stopped", PID: 0})
+	if ci, _ := s.Get("c"); ci.PID != 0 {
+		t.Errorf("Replace left PID=%d, want 0", ci.PID)
+	}
+	if ci, _ := s.Get("c"); ci.LastHealth != "unknown" {
+		t.Errorf("LastHealth=%q, want %q for an empty value", ci.LastHealth, "unknown")
+	}
+}
+
+// singleComponentPlan returns a desired state with one unchanged component plus
+// the matching previous plan entry, so reconcile classifies it as no_touch and
+// the decision rests entirely on liveness.
+func singleComponentPlan(name, healthCheck string) (*plannedState, []state.PlanComponent) {
+	rec := &recipe.Recipe{}
+	rec.Metadata.Name = name
+	rec.Metadata.Version = "1.0.0"
+	rec.Lifecycle.Run.Health.Check = healthCheck
+
+	const digest = "b4c0ffee"
+	recipePath := "configs/examples/" + name + ".toml"
+	pc := &plannedComponent{
+		item:         deploy.Component{Name: name, RecipePath: recipePath},
+		rec:          rec,
+		recipeDigest: digest,
+		recipeID:     recipeIdentity(rec),
+	}
+	planned := &plannedState{
+		path:    "configs/examples/plan.toml",
+		byName:  map[string]*plannedComponent{name: pc},
+		edges:   map[string][]string{},
+		planMap: []state.PlanComponent{{Name: name, RecipePath: recipePath, RecipeMeta: name, RecipeVersion: "1.0.0", RecipeID: pc.recipeID, RecipeDigest: digest}},
+	}
+	return planned, planned.planMap
+}

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -53,6 +53,21 @@ func (s *MemoryStore) Upsert(ci ComponentInfo) {
 	s.mu.Unlock()
 }
 
+// Replace stores ci verbatim, skipping the field-level merge Upsert performs.
+//
+// Upsert reads a zero field as "keep whatever was there", which makes it
+// impossible to clear one: writing PID 0 for a component whose process is gone
+// resurrects the dead PID instead. Callers that own the complete record and
+// need a field back at its zero value use Replace.
+func (s *MemoryStore) Replace(ci ComponentInfo) {
+	s.mu.Lock()
+	if ci.LastHealth == "" {
+		ci.LastHealth = "unknown"
+	}
+	s.items[ci.Name] = ci
+	s.mu.Unlock()
+}
+
 func (s *MemoryStore) List() []ComponentInfo {
 	s.mu.RLock()
 	defer s.mu.RUnlock()


### PR DESCRIPTION
Fixes #10.

## Root cause

Two death paths left `a.comps` out of sync with reality, and one of them fed the other:

- **Reuse from cached state.** `componentIsReady` decided a `no_touch` component could be
  kept running by reading `ci.State` / `ci.LastHealth` only. A reused component gets no
  `RunManaged` call, so if the cached record was stale the agent adopted a corpse with no
  health loop and no restart policy attached.
- **Clean exit not recorded.** The exit callback only updated the store when `err != nil`.
  A process that exits 0 (e.g. traps `SIGTERM`) under `restart_policy = "on-failure"` is
  correctly not restarted, but the component stayed reported `running` / `healthy` with a
  dead PID — which then made it look like a valid reuse candidate forever.

## Changes

- New `supervised` registry: which components actually have a live `RunManaged` loop.
  Set when the loop starts, cleared when it returns and on `stopComponent`.
- `componentIsReady` → `componentIsReusable`: requires `running` **+** a live supervision
  loop **+** a live process (`PID > 0`), plus `healthy` when the recipe declares a health
  check. Container components report PID 0, so for those the supervision loop is the only
  liveness signal.
- The reuse decision is confirmed a second time once the plan is built, closing the window
  between classification and start. When it is revoked, the previous instance is torn down
  (`stopComponent`) before a fresh one starts, so the old loop cannot treat the takeover as
  a failure and fight the new loop over the same component.
- New `handleComponentExit`, used by both the apply path and `restartFromPlan` (which had
  the same error-only callback): every terminal exit updates the state (`stopped` on a clean
  exit, `failed` on error), clears the PID, resets `last_health` and releases the runner.
- `store.MemoryStore.Replace`: `Upsert` treats a zero field as "keep the previous value",
  so `PID = 0` resurrected the dead PID instead of clearing it. Callers that own the whole
  record now use `Replace`.
- The 500 ms state poller no longer re-advertises a PID with no process behind it.

## Acceptance criteria from the issue

- **A** — `TestComponentIsReusable` (dead PID → false, unsupervised → false, alive+supervised
  → true, health matrix) and `TestReconcileRestartsDeadNoTouchComponent` (a dead `no_touch`
  component lands in `startTargets`, not `noTouch`).
- **B** — `TestHandleComponentExit_CleanExit`: `onExit(nil)` leaves `stopped`, `pid = 0`,
  `last_health != healthy`, handle deregistered, runner released.
- **Integration** — verified on a live agent with a two-component plan (`restart_policy = "on-failure"`):

  | Scenario | Result |
  |---|---|
  | `SIGTERM` to a component that exits 0 | `state=stopped`, `pid=0` (was `running/healthy` with a dead PID) |
  | `kill -9` a supervised component | restarted, new PID, `restarts=1` |
  | Re-apply with everything alive | both reused, PIDs unchanged, `restarts=0` |
  | Re-apply with one dead | the dead one starts fresh, the live one is reused |
  | Agent children afterwards | exactly one per component, no orphans, no duplicate loops |

- **No `running`/`healthy` for a nonexistent PID** — guaranteed at every write path: exit
  callback, `stopComponent`, and the state poller.

## Docs

`docs/component-state.md` documents the state table, the liveness guarantees of
`GET /v1/components` and the reuse rules, linked from the README index.

## Known debt, deliberately not in this PR

- The per-apply state poller goroutine is never stopped: N applies leave N pollers.
- `processExists` (agent) duplicates `sysrt.IsProcessRunning`.
- `stopFn` signals the process without deregistering its handle, so a failed apply
  unwinding a layer leaves a dead handle that still reads as `running`. This turns out to be
  the exact mechanism behind the reported incident, and is fixed in the follow-up branch
  (`keystone/reconcile-cleanup`) rather than here. (An earlier version of this list claimed
  the problem was a missing context cancellation; `StartStack` already cancels the loops
  before unwinding — the defect is the missing teardown.)
- `MarkRunningForReuse` bypasses the supervisor FSM; an explicit `adopted` state would be cleaner.