### PR TITLE
fix(agent): tear down components through a single path and stop trusting stale handles

### DIFF
--- a/docs/component-state.md
+++ b/docs/component-state.md
@@ -7,14 +7,21 @@ it.
 
 ## States
 
+These are the states `GET /v1/components` reports:
+
 | State | Meaning |
 |-------|---------|
 | `none` | Known from the plan, nothing installed or started yet |
-| `installing` | Install hook / artifact download in progress |
 | `stopped` | Not running. Either never started, stopped on request, or exited on its own with code 0 and no restart policy that applies |
 | `running` | A managed instance is alive and supervised |
 | `failed` | Terminal failure: crashed with no applicable restart policy, or exhausted `max_retries` |
-| `stopping` | Stop in progress |
+
+The supervisor also has transient lifecycle states — `installing`, `starting`,
+`stopping` — which show up in the agent log as
+`[supervisor] component=<name> state=<state>`. They are not published to the API
+for plan components: an apply moves a component from `none` straight to
+`running` (or `failed`) as far as `/v1/components` is concerned. The one
+exception is the `--demo` stack, which publishes raw supervisor states.
 
 `last_health` is `healthy` / `unhealthy` / `unknown`. Only components that
 declare `[lifecycle.run.health]` ever get a verdict; the rest stay `unknown`
@@ -33,6 +40,8 @@ forever, and that is not a problem.
   last known good state.
 - `last_health` is reset to `unknown` when a component exits: a component that
   is gone cannot still be healthy.
+- A failed apply unwinds through the same teardown as an explicit stop, so a
+  component the agent gave up on does not linger as `running`.
 
 Container components report `pid = 0` (there is no host PID to probe), so for
 those the supervision loop is the only liveness signal.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -68,6 +69,9 @@ type Agent struct {
 	planErr    string
 	// persistence
 	stateDir string
+	// lastSnapshot fingerprints the last snapshot actually written, so an idle
+	// agent stops rewriting the same file twice a second.
+	lastSnapshot string
 	// plan mapping
 	planComps []state.PlanComponent
 	// cache budget
@@ -176,18 +180,70 @@ func New(opts Options) *Agent {
 			log.Printf("[agent] failed to load trust bundle: %v", err)
 		}
 	}
-	// Periodic snapshots
+	a.startStatePoller()
+	return a
+}
+
+// startStatePoller runs the single loop that keeps the component store, the
+// state metrics and the persisted snapshot in step with the handles the agent
+// actually holds.
+//
+// It is started once, from New. Starting one per apply leaked a goroutine per
+// apply, each iterating the component list of a plan that may no longer be the
+// current one.
+func (a *Agent) startStatePoller() {
 	go func() {
-		ticker := time.NewTicker(2 * time.Second)
-		defer ticker.Stop()
-		for range ticker.C {
+		t := time.NewTicker(500 * time.Millisecond)
+		defer t.Stop()
+		for range t.C {
 			if a.closed.Load() {
 				return
 			}
+			a.refreshComponentStates()
 			a.persistSnapshot()
 		}
 	}()
-	return a
+}
+
+// refreshComponentStates reconciles the reported state of every known component
+// with the agent's own bookkeeping, and republishes the state metrics.
+//
+// A component counts as running only if the agent holds a handle for it *and*
+// the process behind that handle is alive. The handle alone is not enough: a
+// stop path that signals the process without deregistering its handle (a failed
+// apply unwinding a layer, for instance) would otherwise keep the component
+// reported running with a dead PID.
+func (a *Agent) refreshComponentStates() {
+	for _, ci := range a.comps.List() {
+		a.mu.RLock()
+		_, hasHandle := a.handles[ci.Name]
+		a.mu.RUnlock()
+
+		running := hasHandle
+		if hasHandle && ci.PID > 0 && !sysrt.IsProcessRunning(ci.PID) {
+			running = false
+		}
+
+		// Keep "failed" state if it was set by a terminal exit.
+		st := ci.State
+		if st != "failed" {
+			st = "stopped"
+			if running {
+				st = "running"
+			}
+			ci.State = st
+			// Never keep advertising a PID with nothing behind it: it may
+			// already have been recycled by an unrelated process.
+			if ci.PID > 0 && !running {
+				ci.PID = 0
+				ci.LastHealth = "unknown"
+			}
+			a.comps.Replace(ci)
+		}
+
+		metrics.ObserveComponentState(ci.Name, st)
+		metrics.ObserveComponentStateWithHealth(ci.Name, st, ci.LastHealth)
+	}
 }
 
 // Close releases agent resources and signals all operations to stop.
@@ -613,29 +669,18 @@ func (a *Agent) applyPlan(planPath string) error {
 		}
 		stopFn := func(ctx context.Context) error {
 			if skipStart {
+				// Reused instance: it was already running before this apply, so
+				// a rollback of this apply must leave it alone.
 				return nil
 			}
-			a.mu.RLock()
-			h := a.handles[it.Name]
-			compRunner := a.runners[it.Name]
-			a.mu.RUnlock()
-			if h == nil {
-				return nil
-			}
-			// Use the stored runner if available, otherwise create appropriate one
-			if compRunner != nil {
-				return compRunner.Stop(ctx, h, 10*time.Second)
-			}
-			// Fallback: create a new runner based on handle type
-			if _, ok := h.(*runner.ProcessHandle); ok {
-				return runner.NewProcessRunner().Stop(ctx, h, 10*time.Second)
-			}
-			// For containers without stored runner, try CLI runner
-			clir, err := runner.NewCLIRunner()
-			if err != nil {
-				return fmt.Errorf("no runner available for container: %w", err)
-			}
-			return clir.Stop(ctx, h, 10*time.Second)
+			// StartStack calls this when a layer fails, to unwind what it
+			// started. Delegate to the one teardown path that also drops the
+			// handle, the runner and the supervision marker, and records the
+			// state: stopping the process alone would leave a dead handle
+			// behind, which still reads as "running" to the API and to the
+			// next reconcile.
+			a.stopComponent(it.Name)
+			return nil
 		}
 		// Create component with readiness channel and register it
 		readyCh := make(chan struct{})
@@ -720,49 +765,6 @@ func (a *Agent) applyPlan(planPath string) error {
 		}
 		a.comps.Upsert(ci)
 	}
-	// Poll states to store and component-state metric
-	go func() {
-		t := time.NewTicker(500 * time.Millisecond)
-		defer t.Stop()
-		for range t.C {
-			if a.closed.Load() {
-				return
-			}
-			for _, c := range comps {
-				// Derive running/stopped from presence of a managed handle.
-				a.mu.RLock()
-				_, running := a.handles[c.Name]
-				a.mu.RUnlock()
-				ci, known := a.comps.Get(c.Name)
-				if !known {
-					continue
-				}
-
-				// Keep "failed" state if it was set by terminal error
-				st := ci.State
-				if st != "failed" {
-					st = "stopped"
-					if running {
-						st = "running"
-					}
-					ci.State = st
-					// Never keep advertising a PID that is gone: with no
-					// managed handle and no live process, the recorded PID
-					// belongs to nothing (and may already be recycled).
-					if ci.PID > 0 && !running && !sysrt.IsProcessRunning(ci.PID) {
-						ci.PID = 0
-						ci.LastHealth = "unknown"
-					}
-					a.comps.Replace(ci)
-				}
-
-				metrics.ObserveComponentState(c.Name, st)
-				metrics.ObserveComponentStateWithHealth(c.Name, st, ci.LastHealth)
-			}
-			a.persistSnapshot()
-		}
-	}()
-
 	err = supervisor.StartStack(a.Context(), comps)
 	a.mu.Lock()
 	if err != nil {
@@ -1131,6 +1133,11 @@ func (a *Agent) persistSnapshot() {
 	a.snapMu.Lock()
 	defer a.snapMu.Unlock()
 
+	comps := a.comps.List()
+	// List() walks a map, so sort for a stable snapshot file (and a stable
+	// fingerprint below).
+	sort.Slice(comps, func(i, j int) bool { return comps[i].Name < comps[j].Name })
+
 	snap := state.Snapshot{
 		Plan: state.PlanStatus{
 			Path:    a.planPath,
@@ -1138,9 +1145,20 @@ func (a *Agent) persistSnapshot() {
 			Error:   a.planErr,
 			Updated: time.Now(),
 		},
-		Components:     a.comps.List(),
+		Components:     comps,
 		PlanComponents: a.planComps,
 	}
+
+	// The state poller calls this twice a second and state.Save rewrites and
+	// renames the file every time; skip the write when nothing observable
+	// changed. Updated is deliberately excluded from the fingerprint, or every
+	// tick would look like a change.
+	fingerprint := fmt.Sprintf("%s|%s|%s|%v|%v", a.planPath, a.planStatus, a.planErr, comps, a.planComps)
+	if fingerprint == a.lastSnapshot {
+		return
+	}
+	a.lastSnapshot = fingerprint
+
 	if err := state.Save(a.stateDir, snap); err != nil {
 		log.Printf("[agent] warning: failed to persist state: %v", err)
 	}
@@ -1484,27 +1502,17 @@ func reapOrphanedComponents(comps []store.ComponentInfo) int {
 		_ = syscall.Kill(ci.PID, syscall.SIGTERM)
 		deadline := time.Now().Add(2 * time.Second)
 		for time.Now().Before(deadline) {
-			if !processExists(ci.PID) {
+			if !sysrt.IsProcessRunning(ci.PID) {
 				break
 			}
 			time.Sleep(100 * time.Millisecond)
 		}
-		if processExists(ci.PID) {
+		if sysrt.IsProcessRunning(ci.PID) {
 			_ = syscall.Kill(ci.PID, syscall.SIGKILL)
 		}
 		reaped++
 	}
 	return reaped
-}
-
-// processExists reports whether a process with this PID is reachable from the
-// current process (sig 0 doesn't deliver anything, it just probes existence
-// and permission).
-func processExists(pid int) bool {
-	if pid <= 0 {
-		return false
-	}
-	return syscall.Kill(pid, 0) == nil
 }
 
 // processIsInitOrphan reports whether the process with PID is currently

--- a/internal/agent/boot_resume_test.go
+++ b/internal/agent/boot_resume_test.go
@@ -7,22 +7,6 @@ import (
 	"github.com/carlosprados/keystone/internal/store"
 )
 
-func TestProcessExists(t *testing.T) {
-	if !processExists(os.Getpid()) {
-		t.Errorf("processExists(self) returned false; the test process exists")
-	}
-	for _, bad := range []int{0, -1, -42} {
-		if processExists(bad) {
-			t.Errorf("processExists(%d) returned true; non-positive PIDs are never valid", bad)
-		}
-	}
-	// 99999999 is well above PID_MAX on Linux (4194303 default) so the lookup
-	// must fail with ESRCH.
-	if processExists(99999999) {
-		t.Errorf("processExists(99999999) returned true; that PID cannot exist")
-	}
-}
-
 func TestProcessIsInitOrphan(t *testing.T) {
 	// The Go test runner is our parent; we are not parented by init.
 	if processIsInitOrphan(os.Getpid()) {

--- a/internal/agent/stale_state_test.go
+++ b/internal/agent/stale_state_test.go
@@ -247,6 +247,48 @@ func TestHandleComponentExit_EndsSupervision(t *testing.T) {
 	}
 }
 
+// TestRefreshComponentStates covers the state poller: holding a handle is not
+// proof of life. A stop path that signals the process without deregistering its
+// handle (a failed apply unwinding a layer) used to leave the component
+// reported running with a dead PID.
+func TestRefreshComponentStates(t *testing.T) {
+	a := newStateAgent()
+	a.comps.Upsert(store.ComponentInfo{Name: "alive", State: "running", LastHealth: "healthy", PID: os.Getpid()})
+	a.comps.Upsert(store.ComponentInfo{Name: "stale", State: "running", LastHealth: "healthy", PID: deadPID})
+	a.comps.Upsert(store.ComponentInfo{Name: "gone", State: "running", LastHealth: "healthy", PID: deadPID})
+	a.comps.Upsert(store.ComponentInfo{Name: "broken", State: "failed", LastHealth: "unhealthy", PID: deadPID})
+	// "alive" and "stale" are both still registered; only one has a live process.
+	a.handles["alive"] = &runner.ProcessHandle{}
+	a.handles["stale"] = &runner.ProcessHandle{}
+	// "gone" lost its handle, the usual case after a terminal exit.
+
+	a.refreshComponentStates()
+
+	for _, c := range []struct {
+		name      string
+		wantState string
+		wantPID   int
+		reason    string
+	}{
+		{"alive", "running", os.Getpid(), "handle plus a live process is the definition of running"},
+		{"stale", "stopped", 0, "the handle is stale: nothing is behind that PID"},
+		{"gone", "stopped", 0, "no handle and no process"},
+		{"broken", "failed", deadPID, "a terminal failure is not downgraded by the poller"},
+	} {
+		ci, ok := a.comps.Get(c.name)
+		if !ok {
+			t.Errorf("%s: missing from the store", c.name)
+			continue
+		}
+		if ci.State != c.wantState {
+			t.Errorf("%s: State=%q, want %q (%s)", c.name, ci.State, c.wantState, c.reason)
+		}
+		if ci.PID != c.wantPID {
+			t.Errorf("%s: PID=%d, want %d (%s)", c.name, ci.PID, c.wantPID, c.reason)
+		}
+	}
+}
+
 func TestMemoryStoreReplaceClearsPID(t *testing.T) {
 	s := store.NewMemoryStore()
 	s.Upsert(store.ComponentInfo{Name: "c", State: "running", PID: 4242, LastHealth: "healthy"})

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -245,6 +245,10 @@ func StartStack(parent context.Context, comps []*Component) error {
 	if err != nil {
 		return err
 	}
+	// started is written by every component goroutine of a layer, so it needs a
+	// mutex: any plan with two components in the same layer would otherwise be
+	// a concurrent map write.
+	var startedMu sync.Mutex
 	started := make(map[string]*Component)
 
 	for i, layer := range layers {
@@ -269,7 +273,9 @@ func StartStack(parent context.Context, comps []*Component) error {
 					errCh <- fmt.Errorf("%s start: %w", c.Name, err)
 					return
 				}
+				startedMu.Lock()
 				started[c.Name] = c
+				startedMu.Unlock()
 			}(comp)
 		}
 		wg.Wait()
@@ -282,7 +288,10 @@ func StartStack(parent context.Context, comps []*Component) error {
 			stopCtx, stopCancel := context.WithTimeout(parent, 30*time.Second)
 			for j := i; j >= 0; j-- {
 				for _, n := range layers[j] {
-					if s, ok := started[n]; ok {
+					startedMu.Lock()
+					s, ok := started[n]
+					startedMu.Unlock()
+					if ok {
 						_ = s.Stop(stopCtx)
 					}
 				}

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -92,3 +92,41 @@ func TestStartStack_Failure(t *testing.T) {
 	assert.Error(t, err)
 	assert.False(t, startedB, "B should not have started")
 }
+
+// TestStartStack_WideLayerFailureUnwinds exercises a layer with several
+// components starting in parallel, one of which fails. The successful siblings
+// must be stopped on the way out — and, under -race, this is what catches
+// concurrent writes to the bookkeeping of what has started.
+func TestStartStack_WideLayerFailureUnwinds(t *testing.T) {
+	var mu sync.Mutex
+	stopped := map[string]bool{}
+
+	stopFn := func(name string) func(context.Context) error {
+		return func(ctx context.Context) error {
+			mu.Lock()
+			stopped[name] = true
+			mu.Unlock()
+			return nil
+		}
+	}
+	okStart := func(context.Context) error { return nil }
+
+	// Four independent components: same layer, started concurrently.
+	comps := []*Component{
+		NewComponent("A", nil, nil, okStart, stopFn("A")),
+		NewComponent("B", nil, nil, okStart, stopFn("B")),
+		NewComponent("C", nil, nil, okStart, stopFn("C")),
+		NewComponent("D", nil, nil, func(ctx context.Context) error {
+			return assert.AnError
+		}, stopFn("D")),
+	}
+
+	err := StartStack(context.Background(), comps)
+	assert.Error(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, name := range []string{"A", "B", "C"} {
+		assert.True(t, stopped[name], "%s started successfully and must be stopped when the layer fails", name)
+	}
+}


### PR DESCRIPTION
Follow-up to #12, addressing the debt that PR listed. Refs #10.

## The one real bug in here

`stopFn` — the hook `StartStack` calls to unwind a layer when an apply fails — signalled the
process but left its handle in `a.handles`, its runner in `a.runners` and its state
untouched. Since the state poller derives "running" from handle presence, the component kept
reading `running` with a dead PID, and the rollback's re-apply then adopted it from cached
state.

That is the exact mechanism behind the incident in #10, and it explains the reporter's log
ordering (`state=running` → `state=stopping` → `signal: killed` → `no_touch=[axiom-influxdb]`
→ "reusing existing running instance"): a failed apply unwound the layer, then rolled back
onto a stale record.

`stopFn` now delegates to `stopComponent`, the single teardown path that cancels the managed
loop, stops the workload, drops the handle and the runner, clears the supervision marker and
records the state.

## Also fixed

- **Concurrent map write in `StartStack`.** Every component goroutine of a layer wrote the
  `started` map unguarded, so any plan with two components in the same layer was a data race
  (verified: removing the new mutex makes `TestStartStack_WideLayerFailureUnwinds` fail under
  `-race` with `WARNING: DATA RACE`).
- **One state poller instead of one per apply.** Each apply used to start a 500 ms goroutine
  that never exited, iterating the component list of a plan that may no longer be current.
  There is now a single poller, started from `New`, iterating the store. It also no longer
  treats a registered handle as proof of life: if the PID behind it is gone, the component is
  not running.
- **Duplicated liveness helper.** `processExists` (agent) did the same job as
  `sysrt.IsProcessRunning`, minus the EPERM case. Removed; its test moved to
  `internal/runtime`, which had none.
- **Snapshot write amplification.** `persistSnapshot` ran on every 500 ms tick and
  `state.Save` rewrites and renames the file every call. It now fingerprints the content and
  skips unchanged writes — an idle agent stops writing to flash entirely — and sorts
  components so the snapshot file is stable.

## Docs correction

`docs/component-state.md` (added in #12) listed the supervisor's transient states as API
states. `installing` / `starting` / `stopping` appear in the log but never in
`GET /v1/components` for plan components — only the `--demo` stack publishes raw supervisor
states. Table corrected.

## Verification

- Full suite green under `-race`; new tests `TestRefreshComponentStates`,
  `TestStartStack_WideLayerFailureUnwinds`, `TestIsProcessRunning`.
- Live agent, apply with a failing install hook so the layer unwinds: the sibling that had
  started is left `stopped` / `pid=0`, and the agent has **zero** child processes. Before this
  change it kept a dead handle and reported `running`.
- Reuse still works: re-applying an unchanged plan leaves PIDs and restart counters untouched.
- Snapshot file stops being rewritten while idle, and updates immediately on a real change.

## Left open

- #13 — container liveness (`pid = 0`, so the supervision loop is the only signal).
- #14 — model adoption explicitly instead of `MarkRunningForReuse` writing state behind the FSM.
