### PR TITLE
feat(runner): confine process components (user, no_new_privileges, capabilities)

### DIFF
--- a/cmd/keystone/main.go
+++ b/cmd/keystone/main.go
@@ -18,10 +18,24 @@ import (
 	natsadapter "github.com/carlosprados/keystone/internal/adapter/nats"
 	"github.com/carlosprados/keystone/internal/agent"
 	"github.com/carlosprados/keystone/internal/config"
+	"github.com/carlosprados/keystone/internal/runner"
 	"github.com/carlosprados/keystone/internal/version"
 )
 
 func main() {
+	// The agent re-executes this binary as a privilege-dropping shim when a
+	// process component declares [lifecycle.run.security]. This has to be the
+	// very first thing main does: the shim must reduce its own privileges and
+	// exec the component, never start an agent.
+	if len(os.Args) > 1 && os.Args[1] == runner.PrivdropFlag {
+		if err := runner.RunPrivdropShim(os.Args[2:]); err != nil {
+			// Fail closed: never fall back to running the component unconfined.
+			fmt.Fprintf(os.Stderr, "keystone: %v\n", err)
+			os.Exit(1)
+		}
+		return // unreachable: RunPrivdropShim execs on success
+	}
+
 	// Load .env as early as possible so adapter configuration (flags/env) can use it.
 	config.LoadDotEnvDefault()
 

--- a/configs/examples/com.keystone.confined.recipe.toml
+++ b/configs/examples/com.keystone.confined.recipe.toml
@@ -1,0 +1,23 @@
+# A process component confined the way a systemd unit would be: its own user,
+# no ability to gain privileges, and exactly one capability.
+#
+# Requires an agent with enough privilege to grant it (root, or holding
+# CAP_NET_BIND_SERVICE and CAP_SETPCAP itself). If a restriction cannot be
+# applied the component refuses to start — it never falls back to unconfined.
+
+[metadata]
+name = "com.keystone.confined"
+version = "1.0.0"
+description = "Example of a confined process component"
+
+[lifecycle.run]
+restart_policy = "on-failure"
+
+[lifecycle.run.security]
+user = "nobody:nogroup"
+no_new_privileges = true
+capabilities = ["CAP_NET_BIND_SERVICE"]
+
+[lifecycle.run.exec]
+command = "/bin/sleep"
+args = ["3600"]

--- a/docs/security.md
+++ b/docs/security.md
@@ -49,6 +49,7 @@ Two trust boundaries matter:
 | Recipe integrity | File-loaded recipes require a detached signature before any hook | secure (fail-closed) |
 | Archive extraction | Zip-slip containment, setuid/world-write mode stripping, size cap | secure |
 | Recipe name/version | Allowlist validator, no path traversal | secure |
+| Process privileges | `[lifecycle.run.security]`: user/group, `no_new_privileges`, capability allow-list | inherits the agent unless declared |
 | Schema | Recipe/plan JSON Schema enforced (not best-effort) | secure |
 | Dev escape | `--insecure-skip-verify` / `KEYSTONE_INSECURE_SKIP_VERIFY=true` | off |
 
@@ -217,6 +218,76 @@ remotely-reachable API is authenticated. Review and adjust before production.
 
 ---
 
+## Process privileges
+
+By default a process component inherits everything from the agent: same uid, same
+capabilities, `NoNewPrivs=0`. When the agent runs as root — which it usually must,
+to install services — so does every component. A recipe closes that with:
+
+```toml
+[lifecycle.run.security]
+user = "svc:svc"                                # "user", "uid", "user:group" or "uid:gid"
+no_new_privileges = true                        # PR_SET_NO_NEW_PRIVS
+capabilities = ["CAP_NET_BIND_SERVICE"]         # allow-list; [] means none at all
+```
+
+This is the equivalent of `User=`, `NoNewPrivileges=` and `AmbientCapabilities=`
+in a systemd unit, and the names are the same, so an existing unit can be copied
+across.
+
+**Applies to process components only.** Containers are confined through
+`[lifecycle.run.container]`; declaring `[lifecycle.run.security]` on a container
+component is an error, as is setting `container.user` / `container.privileged` on
+a process component. A restriction is never accepted and ignored.
+
+### How it is enforced
+
+Dropping the capability bounding set and setting `PR_SET_NO_NEW_PRIVS` are
+per-process and irreversible, so they cannot be done in the agent — it would
+confine the agent itself and everything it later starts. Instead the agent
+re-executes its own binary as a shim (`keystone --privdrop-exec …`), which
+reduces its privileges, **verifies the result**, and only then `exec`s the
+component. The `exec` keeps the same PID, so supervision, metrics and
+`GET /v1/components` are unaffected.
+
+Order matters and follows systemd's: keep capabilities across the uid change,
+close the bounding set (while `CAP_SETPCAP` is still effective), switch group and
+user, narrow the capability sets, raise the survivors into the *ambient* set so
+they survive `exec`, set `no_new_privileges`, verify, exec.
+
+### Fail-closed
+
+If any requested restriction cannot be applied, the component does **not** start:
+the shim exits non-zero and the failure is reported like any other start failure.
+An unconfined process is never the fallback. Verification is done against the
+kernel — `getuid`, `capget`, `PR_CAP_AMBIENT_IS_SET`, `PR_GET_NO_NEW_PRIVS` — not
+against the fact that the syscalls returned 0.
+
+Two cases are worth knowing:
+
+- **Asking for a capability the agent does not hold** fails: a process can only
+  ever narrow its own capabilities. Run the agent with that capability, or drop it
+  from the recipe.
+- **A non-root agent cannot narrow the bounding set** (`PR_CAPBSET_DROP` needs
+  `CAP_SETPCAP`). With `no_new_privileges = true` this is logged and accepted,
+  because the bounding set can only be exploited by an `execve` that grants
+  privileges, which is precisely what `no_new_privileges` forbids. Without
+  `no_new_privileges` the hole is real and the component is refused.
+
+### Verifying it on a device
+
+```console
+$ grep -E 'Uid|Gid|CapEff|CapBnd|CapAmb|NoNewPrivs' /proc/<pid>/status
+Uid:	65534	65534	65534	65534
+Gid:	65534	65534	65534	65534
+CapEff:	0000000000000400      # CAP_NET_BIND_SERVICE only
+CapBnd:	0000000000000400
+CapAmb:	0000000000000400
+NoNewPrivs:	1
+```
+
+---
+
 ## Known limitations
 
 Honest list of what is **not** yet covered (tracked as follow-ups):
@@ -225,9 +296,9 @@ Honest list of what is **not** yet covered (tracked as follow-ups):
   only. NATS/MQTT still accept it; they are disabled by default and rely on
   broker ACLs.
 - **Release signing:** released binaries are not yet signed (no cosign/SBOM).
-- **Workload privilege dropping:** spawned processes inherit the agent's
-  privileges; there is no per-component uid/gid drop yet, and `privileged`
-  containers / host mounts are not gated by policy.
+- **Container confinement:** `privileged` containers and host mounts are not
+  gated by policy. Process components can now be confined (see *Process
+  privileges* below), containers only through `[lifecycle.run.container]`.
 - **Child environment:** recipe-supplied env is not stripped of `LD_PRELOAD` /
   `LD_LIBRARY_PATH` for process workloads.
 - **State snapshot integrity:** `runtime/state` is not integrity-protected.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -546,6 +546,9 @@ func (a *Agent) applyPlan(planPath string) error {
 
 			// Determine run type and validate
 			runType := r.Lifecycle.Run.Type
+			if err := validateRunSecurity(r); err != nil {
+				return fmt.Errorf("component %s: %w", it.Name, err)
+			}
 			if runType == "" || runType == "process" {
 				// Validate command availability for processes
 				cmdPath := r.Lifecycle.Run.Exec.Command
@@ -1005,6 +1008,40 @@ func (a *Agent) createRunner(r *recipe.Recipe) (runner.Runner, func(), error) {
 }
 
 // buildRunnerOptions builds runner.Options from a recipe.
+// recipeSecurity maps the recipe's security block to the runner's.
+func recipeSecurity(r *recipe.Recipe) runner.Security {
+	sec := r.Lifecycle.Run.Security
+	return runner.Security{
+		User:            sec.User,
+		NoNewPrivileges: sec.NoNewPrivileges,
+		Capabilities:    sec.Capabilities,
+	}
+}
+
+// validateRunSecurity rejects privilege settings that the runner for this
+// component type cannot honour.
+//
+// The rule is that a restriction an operator writes in a recipe either takes
+// effect or is refused: silently accepting one and running the workload
+// unconfined is how you end up believing a service is sandboxed when it is not.
+func validateRunSecurity(r *recipe.Recipe) error {
+	runType := r.Lifecycle.Run.Type
+	container := r.Lifecycle.Run.Container
+	sec := recipeSecurity(r)
+
+	if runType == "" || runType == "process" {
+		if container.User != "" || container.Privileged {
+			return fmt.Errorf("run.container.user/privileged only apply to container components and would be ignored here; use [lifecycle.run.security] for a process component")
+		}
+		return sec.Validate()
+	}
+
+	if !sec.IsZero() {
+		return fmt.Errorf("[lifecycle.run.security] only applies to process components; confine a container through [lifecycle.run.container] (user, privileged) instead")
+	}
+	return nil
+}
+
 func buildRunnerOptions(name string, r *recipe.Recipe, workDir string) runner.Options {
 	runType := r.Lifecycle.Run.Type
 	if runType == "" || runType == "process" {
@@ -1020,6 +1057,7 @@ func buildRunnerOptions(name string, r *recipe.Recipe, workDir string) runner.Op
 			Env:        env,
 			WorkingDir: workDir,
 			NoFile:     r.Resources.OpenFiles,
+			Security:   recipeSecurity(r),
 		}
 	}
 
@@ -1250,6 +1288,9 @@ func (a *Agent) restartFromPlan(name string) error {
 
 	// Determine run type and validate
 	runType := r.Lifecycle.Run.Type
+	if err := validateRunSecurity(r); err != nil {
+		return fmt.Errorf("component %s: %w", name, err)
+	}
 	if runType == "" || runType == "process" {
 		if cmd := r.Lifecycle.Run.Exec.Command; strings.HasPrefix(cmd, "./") {
 			abs := filepath.Join(workDir, strings.TrimPrefix(cmd, "./"))

--- a/internal/agent/stale_state_test.go
+++ b/internal/agent/stale_state_test.go
@@ -333,3 +333,62 @@ func singleComponentPlan(name, healthCheck string) (*plannedState, []state.PlanC
 	}
 	return planned, planned.planMap
 }
+
+// TestValidateRunSecurity is the "no silent no-op" contract: a privilege
+// restriction the runner for this component type cannot honour must be refused
+// when the plan is applied, never accepted and ignored.
+func TestValidateRunSecurity(t *testing.T) {
+	processRecipe := func(mutate func(*recipe.Recipe)) *recipe.Recipe {
+		r := &recipe.Recipe{}
+		r.Metadata.Name = "svc"
+		r.Lifecycle.Run.Exec.Command = "/bin/true"
+		mutate(r)
+		return r
+	}
+
+	t.Run("valid process security is accepted", func(t *testing.T) {
+		r := processRecipe(func(r *recipe.Recipe) {
+			r.Lifecycle.Run.Security.NoNewPrivileges = true
+			r.Lifecycle.Run.Security.Capabilities = []string{"CAP_NET_BIND_SERVICE"}
+		})
+		if err := validateRunSecurity(r); err != nil {
+			t.Errorf("valid security block rejected: %v", err)
+		}
+	})
+
+	t.Run("unknown capability is rejected", func(t *testing.T) {
+		r := processRecipe(func(r *recipe.Recipe) {
+			r.Lifecycle.Run.Security.Capabilities = []string{"CAP_NOT_A_THING"}
+		})
+		if err := validateRunSecurity(r); err == nil {
+			t.Error("a typo in a capability name must fail the apply")
+		}
+	})
+
+	t.Run("container-only privilege fields on a process component are rejected", func(t *testing.T) {
+		for _, mutate := range []func(*recipe.Recipe){
+			func(r *recipe.Recipe) { r.Lifecycle.Run.Container.User = "1000:1000" },
+			func(r *recipe.Recipe) { r.Lifecycle.Run.Container.Privileged = true },
+		} {
+			if err := validateRunSecurity(processRecipe(mutate)); err == nil {
+				t.Error("container.user/privileged on a process component must be refused, not ignored")
+			}
+		}
+	})
+
+	t.Run("process security on a container component is rejected", func(t *testing.T) {
+		r := &recipe.Recipe{}
+		r.Lifecycle.Run.Type = "container"
+		r.Lifecycle.Run.Container.Image = "docker.io/library/nginx:latest"
+		r.Lifecycle.Run.Security.NoNewPrivileges = true
+		if err := validateRunSecurity(r); err == nil {
+			t.Error("[lifecycle.run.security] on a container component must be refused")
+		}
+	})
+
+	t.Run("a recipe without any privilege settings is fine", func(t *testing.T) {
+		if err := validateRunSecurity(processRecipe(func(*recipe.Recipe) {})); err != nil {
+			t.Errorf("plain recipe rejected: %v", err)
+		}
+	})
+}

--- a/internal/recipe/types.go
+++ b/internal/recipe/types.go
@@ -82,10 +82,33 @@ type ContainerResources struct {
 	PidsLimit  int64 `toml:"pids_limit"`  // Max number of PIDs
 }
 
+// SecurityConfig restricts the privileges of a process component. It is the
+// process-runner counterpart of a systemd unit's User=, NoNewPrivileges= and
+// AmbientCapabilities=, and it applies only to `type = "process"`; containers
+// are confined through [lifecycle.run.container] instead.
+//
+// Everything declared here is enforced or the component refuses to start: a
+// restriction that cannot be applied is an error, never a silent no-op.
+type SecurityConfig struct {
+	// User to run the process as: "user", "uid", "user:group" or "uid:gid".
+	// Empty means the agent's own user, which is usually root.
+	User string `toml:"user"`
+	// NoNewPrivileges forbids gaining privileges through execve, for this
+	// process and everything it starts. Irreversible once set.
+	NoNewPrivileges bool `toml:"no_new_privileges"`
+	// Capabilities is the allow-list of capabilities the process may ever hold,
+	// e.g. ["CAP_NET_BIND_SERVICE"]. Declaring the key — even as an empty list,
+	// which means "none at all" — drops everything else from the bounding set.
+	// Omitting it leaves capabilities untouched, so nil and [] differ on
+	// purpose.
+	Capabilities []string `toml:"capabilities"`
+}
+
 type LifecycleRun struct {
 	Type          string           `toml:"type"` // "process" (default) or "container"
 	Exec          LifecycleRunExec `toml:"exec"`
 	Container     ContainerConfig  `toml:"container"`
+	Security      SecurityConfig   `toml:"security"`
 	RestartPolicy string           `toml:"restart_policy"`
 	MaxRetries    int              `toml:"max_retries"`
 	Health        Health           `toml:"health"`

--- a/internal/runner/capabilities.go
+++ b/internal/runner/capabilities.go
@@ -1,0 +1,99 @@
+//go:build linux
+
+package runner
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// capabilityNumbers maps the capability names an operator writes in a recipe to
+// the kernel's numbers. The names are the same ones systemd and `capsh` use, so
+// an existing unit's AmbientCapabilities can be copied across verbatim.
+var capabilityNumbers = map[string]uintptr{
+	"CAP_CHOWN":              unix.CAP_CHOWN,
+	"CAP_DAC_OVERRIDE":       unix.CAP_DAC_OVERRIDE,
+	"CAP_DAC_READ_SEARCH":    unix.CAP_DAC_READ_SEARCH,
+	"CAP_FOWNER":             unix.CAP_FOWNER,
+	"CAP_FSETID":             unix.CAP_FSETID,
+	"CAP_KILL":               unix.CAP_KILL,
+	"CAP_SETGID":             unix.CAP_SETGID,
+	"CAP_SETUID":             unix.CAP_SETUID,
+	"CAP_SETPCAP":            unix.CAP_SETPCAP,
+	"CAP_LINUX_IMMUTABLE":    unix.CAP_LINUX_IMMUTABLE,
+	"CAP_NET_BIND_SERVICE":   unix.CAP_NET_BIND_SERVICE,
+	"CAP_NET_BROADCAST":      unix.CAP_NET_BROADCAST,
+	"CAP_NET_ADMIN":          unix.CAP_NET_ADMIN,
+	"CAP_NET_RAW":            unix.CAP_NET_RAW,
+	"CAP_IPC_LOCK":           unix.CAP_IPC_LOCK,
+	"CAP_IPC_OWNER":          unix.CAP_IPC_OWNER,
+	"CAP_SYS_MODULE":         unix.CAP_SYS_MODULE,
+	"CAP_SYS_RAWIO":          unix.CAP_SYS_RAWIO,
+	"CAP_SYS_CHROOT":         unix.CAP_SYS_CHROOT,
+	"CAP_SYS_PTRACE":         unix.CAP_SYS_PTRACE,
+	"CAP_SYS_PACCT":          unix.CAP_SYS_PACCT,
+	"CAP_SYS_ADMIN":          unix.CAP_SYS_ADMIN,
+	"CAP_SYS_BOOT":           unix.CAP_SYS_BOOT,
+	"CAP_SYS_NICE":           unix.CAP_SYS_NICE,
+	"CAP_SYS_RESOURCE":       unix.CAP_SYS_RESOURCE,
+	"CAP_SYS_TIME":           unix.CAP_SYS_TIME,
+	"CAP_SYS_TTY_CONFIG":     unix.CAP_SYS_TTY_CONFIG,
+	"CAP_MKNOD":              unix.CAP_MKNOD,
+	"CAP_LEASE":              unix.CAP_LEASE,
+	"CAP_AUDIT_WRITE":        unix.CAP_AUDIT_WRITE,
+	"CAP_AUDIT_CONTROL":      unix.CAP_AUDIT_CONTROL,
+	"CAP_SETFCAP":            unix.CAP_SETFCAP,
+	"CAP_MAC_OVERRIDE":       unix.CAP_MAC_OVERRIDE,
+	"CAP_MAC_ADMIN":          unix.CAP_MAC_ADMIN,
+	"CAP_SYSLOG":             unix.CAP_SYSLOG,
+	"CAP_WAKE_ALARM":         unix.CAP_WAKE_ALARM,
+	"CAP_BLOCK_SUSPEND":      unix.CAP_BLOCK_SUSPEND,
+	"CAP_AUDIT_READ":         unix.CAP_AUDIT_READ,
+	"CAP_PERFMON":            unix.CAP_PERFMON,
+	"CAP_BPF":                unix.CAP_BPF,
+	"CAP_CHECKPOINT_RESTORE": unix.CAP_CHECKPOINT_RESTORE,
+}
+
+// lastKnownCapability is the highest capability number this build knows about.
+// Iterating past it is harmless (the kernel answers EINVAL) but pointless.
+const lastKnownCapability = uintptr(unix.CAP_CHECKPOINT_RESTORE)
+
+// capabilityByName resolves a recipe-provided capability name. Both "CAP_NET_RAW"
+// and "net_raw" are accepted, case-insensitively.
+func capabilityByName(name string) (uintptr, error) {
+	key := strings.ToUpper(strings.TrimSpace(name))
+	if key == "" {
+		return 0, fmt.Errorf("empty capability name")
+	}
+	if !strings.HasPrefix(key, "CAP_") {
+		key = "CAP_" + key
+	}
+	c, ok := capabilityNumbers[key]
+	if !ok {
+		return 0, fmt.Errorf("unknown capability %q (see `man 7 capabilities` for the list this build knows)", name)
+	}
+	return c, nil
+}
+
+// capabilityName is the inverse of capabilityByName, for log and error messages.
+func capabilityName(c uintptr) string {
+	for name, n := range capabilityNumbers {
+		if n == c {
+			return name
+		}
+	}
+	return fmt.Sprintf("CAP_%d", c)
+}
+
+// capabilityNames renders a set of capability numbers in a stable order.
+func capabilityNames(caps []uintptr) []string {
+	out := make([]string, 0, len(caps))
+	for _, c := range caps {
+		out = append(out, capabilityName(c))
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/runner/privdrop.go
+++ b/internal/runner/privdrop.go
@@ -1,0 +1,567 @@
+//go:build linux
+
+package runner
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/user"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// PrivdropFlag is the hidden argv[1] that turns the keystone binary into the
+// privilege-dropping shim. See RunPrivdropShim.
+const PrivdropFlag = "--privdrop-exec"
+
+// Security describes the privilege restrictions to apply to a process
+// component before it is executed. The zero value means "inherit everything
+// from the agent", which is what happens without a [lifecycle.run.security]
+// block in the recipe.
+type Security struct {
+	// User is "user", "uid", "user:group" or "uid:gid". An empty value keeps
+	// the agent's own uid/gid.
+	User string
+	// NoNewPrivileges sets PR_SET_NO_NEW_PRIVS, so the process and its children
+	// can never gain privileges through execve (setuid binaries, file
+	// capabilities).
+	NoNewPrivileges bool
+	// Capabilities is the allow-list of capability names ("CAP_NET_BIND_SERVICE").
+	// When non-nil, every capability outside the list is dropped from the
+	// bounding set, so the process can never acquire it. A non-nil empty slice
+	// therefore means "no capabilities at all".
+	Capabilities []string
+}
+
+// IsZero reports whether nothing was requested.
+func (s Security) IsZero() bool {
+	return s.User == "" && !s.NoNewPrivileges && s.Capabilities == nil
+}
+
+// describe renders the restrictions for the log line that records them, so an
+// operator can see in the journal what a component was actually confined to.
+func (s Security) describe() string {
+	parts := make([]string, 0, 3)
+	if s.User != "" {
+		parts = append(parts, "user="+s.User)
+	}
+	if s.NoNewPrivileges {
+		parts = append(parts, "no_new_privileges=true")
+	}
+	if s.Capabilities != nil {
+		if len(s.Capabilities) == 0 {
+			parts = append(parts, "capabilities=none")
+		} else {
+			parts = append(parts, "capabilities="+strings.Join(s.Capabilities, "+"))
+		}
+	}
+	return strings.Join(parts, ",")
+}
+
+// resolvedSecurity is Security with names turned into numbers, ready to apply.
+type resolvedSecurity struct {
+	uid, gid        int
+	changeUser      bool
+	groups          []int
+	noNewPrivileges bool
+	caps            []uintptr
+	capsSet         bool
+}
+
+// Validate resolves and checks everything that can be checked without applying
+// it, so a bad recipe fails when the plan is applied rather than at exec time.
+func (s Security) Validate() error {
+	_, err := s.resolve()
+	return err
+}
+
+func (s Security) resolve() (resolvedSecurity, error) {
+	var out resolvedSecurity
+	out.noNewPrivileges = s.NoNewPrivileges
+
+	if s.User != "" {
+		uid, gid, groups, err := resolveUser(s.User)
+		if err != nil {
+			return out, err
+		}
+		out.uid, out.gid, out.groups, out.changeUser = uid, gid, groups, true
+	}
+
+	if s.Capabilities != nil {
+		out.capsSet = true
+		out.caps = make([]uintptr, 0, len(s.Capabilities))
+		seen := map[uintptr]bool{}
+		for _, name := range s.Capabilities {
+			c, err := capabilityByName(name)
+			if err != nil {
+				return out, err
+			}
+			if seen[c] {
+				continue
+			}
+			seen[c] = true
+			out.caps = append(out.caps, c)
+		}
+	}
+	return out, nil
+}
+
+// resolveUser turns "user", "uid", "user:group" or "uid:gid" into ids. When only
+// a user is given, its primary group and supplementary groups are used, which is
+// what an operator expects from `User=` in a systemd unit.
+func resolveUser(spec string) (uid, gid int, groups []int, err error) {
+	userPart, groupPart, hasGroup := strings.Cut(spec, ":")
+	userPart = strings.TrimSpace(userPart)
+	groupPart = strings.TrimSpace(groupPart)
+	if userPart == "" {
+		return 0, 0, nil, fmt.Errorf("security.user %q: empty user", spec)
+	}
+
+	var u *user.User
+	if n, convErr := strconv.Atoi(userPart); convErr == nil {
+		if n < 0 {
+			return 0, 0, nil, fmt.Errorf("security.user %q: negative uid", spec)
+		}
+		uid = n
+		// Look the uid up for its groups; not being in /etc/passwd is allowed.
+		u, _ = user.LookupId(userPart)
+	} else {
+		u, err = user.Lookup(userPart)
+		if err != nil {
+			return 0, 0, nil, fmt.Errorf("security.user %q: unknown user %q: %w", spec, userPart, err)
+		}
+		if uid, err = strconv.Atoi(u.Uid); err != nil {
+			return 0, 0, nil, fmt.Errorf("security.user %q: unusable uid %q: %w", spec, u.Uid, err)
+		}
+	}
+
+	switch {
+	case hasGroup && groupPart != "":
+		if n, convErr := strconv.Atoi(groupPart); convErr == nil {
+			if n < 0 {
+				return 0, 0, nil, fmt.Errorf("security.user %q: negative gid", spec)
+			}
+			gid = n
+		} else {
+			g, lookupErr := user.LookupGroup(groupPart)
+			if lookupErr != nil {
+				return 0, 0, nil, fmt.Errorf("security.user %q: unknown group %q: %w", spec, groupPart, lookupErr)
+			}
+			if gid, err = strconv.Atoi(g.Gid); err != nil {
+				return 0, 0, nil, fmt.Errorf("security.user %q: unusable gid %q: %w", spec, g.Gid, err)
+			}
+		}
+	case u != nil:
+		if gid, err = strconv.Atoi(u.Gid); err != nil {
+			return 0, 0, nil, fmt.Errorf("security.user %q: unusable primary gid %q: %w", spec, u.Gid, err)
+		}
+	default:
+		return 0, 0, nil, fmt.Errorf("security.user %q: uid %d is not in the user database, so it has no primary group: give it explicitly as \"uid:gid\"", spec, uid)
+	}
+
+	// Supplementary groups, best effort: only available for a known user.
+	if u != nil {
+		if ids, gerr := u.GroupIds(); gerr == nil {
+			for _, s := range ids {
+				if n, convErr := strconv.Atoi(s); convErr == nil && n != gid {
+					groups = append(groups, n)
+				}
+			}
+		}
+	}
+	return uid, gid, groups, nil
+}
+
+// shimArgs renders the resolved restrictions as the argv of the shim, followed
+// by the command to execute.
+func (s Security) shimArgs(command string, args []string) ([]string, error) {
+	res, err := s.resolve()
+	if err != nil {
+		return nil, err
+	}
+	out := []string{PrivdropFlag}
+	if res.changeUser {
+		out = append(out, "--uid="+strconv.Itoa(res.uid), "--gid="+strconv.Itoa(res.gid))
+		if len(res.groups) > 0 {
+			gs := make([]string, 0, len(res.groups))
+			for _, g := range res.groups {
+				gs = append(gs, strconv.Itoa(g))
+			}
+			out = append(out, "--groups="+strings.Join(gs, ","))
+		}
+	}
+	if res.noNewPrivileges {
+		out = append(out, "--no-new-privs")
+	}
+	if res.capsSet {
+		names := make([]string, 0, len(res.caps))
+		for _, c := range res.caps {
+			names = append(names, capabilityName(c))
+		}
+		// Always present when capabilities are restricted, even if empty: that
+		// is how the shim tells "drop everything" from "not requested".
+		out = append(out, "--caps="+strings.Join(names, ","))
+	}
+	out = append(out, "--", command)
+	return append(out, args...), nil
+}
+
+// RunPrivdropShim is the entry point of the privilege-dropping shim: the agent
+// re-executes its own binary with PrivdropFlag, the shim reduces its own
+// privileges, verifies the result, and only then execs the real command. It
+// never returns on success — the process image is replaced, so the PID the agent
+// supervises stays the same.
+//
+// Doing this in a shim rather than in the parent is not a detour: dropping the
+// capability bounding set and setting PR_SET_NO_NEW_PRIVS are per-process
+// operations that would otherwise apply to the agent itself and be inherited by
+// everything it starts, and they are irreversible.
+//
+// Order matters and follows what systemd does: keep capabilities across the uid
+// change, switch group then user, restrict capabilities, forbid regaining
+// privileges, exec.
+func RunPrivdropShim(argv []string) error {
+	req, err := parseShimArgs(argv)
+	if err != nil {
+		return err
+	}
+
+	var caps []uintptr
+	for _, n := range req.capNames {
+		c, err := capabilityByName(n)
+		if err != nil {
+			return fmt.Errorf("privdrop: %w", err)
+		}
+		caps = append(caps, c)
+	}
+
+	if err := applyPrivdrop(req.uid, req.gid, req.groups, caps, req.capsRequested, req.noNewPrivs); err != nil {
+		return err
+	}
+
+	return unix.Exec(req.command, append([]string{req.command}, req.commandArgs...), os.Environ())
+}
+
+// shimRequest is what the shim was asked to do, as parsed from its argv.
+type shimRequest struct {
+	uid, gid      int
+	groups        []int
+	noNewPrivs    bool
+	capsRequested bool
+	capNames      []string
+	command       string
+	commandArgs   []string
+}
+
+// parseShimArgs reads the argv the runner rendered. Anything unrecognised is an
+// error rather than something to skip: this argv decides how confined a process
+// runs, so a typo must stop the component, not weaken it.
+func parseShimArgs(argv []string) (shimRequest, error) {
+	req := shimRequest{uid: -1, gid: -1}
+	sawSentinel := false
+
+	for _, arg := range argv {
+		if sawSentinel {
+			if req.command == "" {
+				req.command = arg
+			} else {
+				req.commandArgs = append(req.commandArgs, arg)
+			}
+			continue
+		}
+		switch {
+		case arg == "--":
+			sawSentinel = true
+		case arg == "--no-new-privs":
+			req.noNewPrivs = true
+		case strings.HasPrefix(arg, "--uid="):
+			n, err := strconv.Atoi(strings.TrimPrefix(arg, "--uid="))
+			if err != nil {
+				return req, fmt.Errorf("privdrop: bad --uid: %w", err)
+			}
+			req.uid = n
+		case strings.HasPrefix(arg, "--gid="):
+			n, err := strconv.Atoi(strings.TrimPrefix(arg, "--gid="))
+			if err != nil {
+				return req, fmt.Errorf("privdrop: bad --gid: %w", err)
+			}
+			req.gid = n
+		case strings.HasPrefix(arg, "--groups="):
+			for _, s := range strings.Split(strings.TrimPrefix(arg, "--groups="), ",") {
+				if s == "" {
+					continue
+				}
+				n, err := strconv.Atoi(s)
+				if err != nil {
+					return req, fmt.Errorf("privdrop: bad --groups entry %q: %w", s, err)
+				}
+				req.groups = append(req.groups, n)
+			}
+		case strings.HasPrefix(arg, "--caps="):
+			req.capsRequested = true
+			for _, s := range strings.Split(strings.TrimPrefix(arg, "--caps="), ",") {
+				if s = strings.TrimSpace(s); s != "" {
+					req.capNames = append(req.capNames, s)
+				}
+			}
+		default:
+			return req, fmt.Errorf("privdrop: unknown argument %q", arg)
+		}
+	}
+	if req.command == "" {
+		return req, fmt.Errorf("privdrop: no command to execute")
+	}
+	return req, nil
+}
+
+func applyPrivdrop(uid, gid int, groups []int, caps []uintptr, capsRequested, noNewPrivs bool) error {
+	boundingSetNarrowed := false
+	if capsRequested {
+		// Keep the permitted set across the uid change; without this, switching
+		// away from uid 0 clears all capabilities and the allow-list could not
+		// be honoured.
+		if len(caps) > 0 {
+			if err := unix.Prctl(unix.PR_SET_KEEPCAPS, 1, 0, 0, 0); err != nil {
+				return fmt.Errorf("privdrop: PR_SET_KEEPCAPS: %w", err)
+			}
+		}
+		// The bounding set must be closed *before* the identity switch: doing so
+		// needs CAP_SETPCAP in the effective set, and setuid clears the
+		// effective set.
+		var err error
+		if boundingSetNarrowed, err = dropBoundingSet(caps, noNewPrivs); err != nil {
+			return err
+		}
+	}
+
+	// Switching identity is skipped when the target is the identity we already
+	// have: a recipe that says user = "svc" must work both under a root agent
+	// (which switches) and under an agent already running as svc (which has
+	// nothing to switch and no privilege to call setgroups with).
+	changingUser := (uid >= 0 && uid != unix.Getuid()) || (gid >= 0 && gid != unix.Getgid())
+	if changingUser {
+		// Always set the supplementary groups, including to the empty set:
+		// inheriting the agent's groups (root's, typically) would leave the
+		// component with access the recipe did not ask for.
+		if err := unix.Setgroups(groups); err != nil {
+			return fmt.Errorf("privdrop: setgroups %v: %w", groups, err)
+		}
+		if gid >= 0 {
+			if err := unix.Setgid(gid); err != nil {
+				return fmt.Errorf("privdrop: setgid %d: %w", gid, err)
+			}
+		}
+		if uid >= 0 {
+			if err := unix.Setuid(uid); err != nil {
+				return fmt.Errorf("privdrop: setuid %d: %w", uid, err)
+			}
+		}
+	}
+
+	if capsRequested {
+		if err := setCapabilities(caps); err != nil {
+			return err
+		}
+	}
+
+	if noNewPrivs {
+		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+			return fmt.Errorf("privdrop: PR_SET_NO_NEW_PRIVS: %w", err)
+		}
+	}
+
+	return verifyPrivdrop(uid, gid, caps, capsRequested, boundingSetNarrowed, noNewPrivs)
+}
+
+// capMask renders capability numbers as the two 32-bit words the capset ABI and
+// /proc/<pid>/status use.
+func capMask(caps []uintptr) [2]uint32 {
+	var mask [2]uint32
+	for _, c := range caps {
+		if c < 32 {
+			mask[0] |= 1 << c
+		} else {
+			mask[1] |= 1 << (c - 32)
+		}
+	}
+	return mask
+}
+
+// dropBoundingSet strips every capability outside the allow-list from the
+// bounding set, so nothing outside it can ever be acquired by this process or its
+// children. It must run before the identity switch: PR_CAPBSET_DROP needs
+// CAP_SETPCAP in the *effective* set, and setuid clears the effective set.
+//
+// It reports whether the bounding set was actually narrowed. Narrowing it
+// requires CAP_SETPCAP, which an agent that is not root does not have. That is
+// not fatal *if* no_new_privileges is also being set: the bounding set only
+// matters when execve would otherwise grant capabilities (a setuid binary, or one
+// carrying file capabilities), and PR_SET_NO_NEW_PRIVS forbids exactly that.
+// Without no_new_privileges the hole is real, so this fails instead.
+func dropBoundingSet(caps []uintptr, noNewPrivs bool) (narrowed bool, err error) {
+	allowed := make(map[uintptr]bool, len(caps))
+	for _, c := range caps {
+		allowed[c] = true
+	}
+	for c := uintptr(0); c <= lastKnownCapability; c++ {
+		if allowed[c] {
+			continue
+		}
+		switch err := unix.Prctl(unix.PR_CAPBSET_DROP, c, 0, 0, 0); {
+		case err == nil, err == unix.EINVAL: // EINVAL: unknown to this kernel
+			continue
+		case err == unix.EPERM && noNewPrivs:
+			log.Printf("[runner] privdrop: cannot narrow the capability bounding set without CAP_SETPCAP; no_new_privileges=true already prevents gaining capabilities through execve, continuing")
+			return false, nil
+		case err == unix.EPERM:
+			return false, fmt.Errorf("privdrop: cannot narrow the capability bounding set (%s): CAP_SETPCAP is required. Either run the agent as root or with CAP_SETPCAP, or add no_new_privileges = true, which closes the same hole without it", capabilityName(c))
+		default:
+			return false, fmt.Errorf("privdrop: PR_CAPBSET_DROP %s: %w", capabilityName(c), err)
+		}
+	}
+	return true, nil
+}
+
+// setCapabilities narrows the permitted, effective and inheritable sets to the
+// allow-list and raises those capabilities into the ambient set. The ambient set
+// is what makes them survive the execve of an ordinary binary — one without file
+// capabilities, which is the normal case for a component — so skipping it would
+// leave the process with nothing at all.
+//
+// It must run after the identity switch: setuid clears the effective set (and,
+// without PR_SET_KEEPCAPS, the permitted set too).
+func setCapabilities(caps []uintptr) error {
+	mask := capMask(caps)
+	hdr := unix.CapUserHeader{Version: unix.LINUX_CAPABILITY_VERSION_3, Pid: 0}
+	data := [2]unix.CapUserData{
+		{Effective: mask[0], Permitted: mask[0], Inheritable: mask[0]},
+		{Effective: mask[1], Permitted: mask[1], Inheritable: mask[1]},
+	}
+	if err := unix.Capset(&hdr, &data[0]); err != nil {
+		if err == unix.EPERM {
+			// A process can only ever narrow its own capabilities, so this means
+			// the agent does not hold what the recipe asks to grant.
+			return fmt.Errorf("privdrop: cannot grant %s: the keystone agent does not hold it in its own permitted set (run the agent with that capability, or remove it from [lifecycle.run.security])",
+				strings.Join(capabilityNames(caps), "+"))
+		}
+		return fmt.Errorf("privdrop: capset to %v: %w", capabilityNames(caps), err)
+	}
+
+	for _, c := range caps {
+		if err := unix.Prctl(unix.PR_CAP_AMBIENT, unix.PR_CAP_AMBIENT_RAISE, c, 0, 0); err != nil {
+			return fmt.Errorf("privdrop: PR_CAP_AMBIENT_RAISE %s (without it the capability would not survive exec): %w", capabilityName(c), err)
+		}
+	}
+	return nil
+}
+
+// verifyPrivdrop refuses to exec if the restrictions did not actually take
+// effect. Fail-closed: a component whose confinement silently did not apply
+// must not run, which is the whole complaint behind this feature.
+func verifyPrivdrop(uid, gid int, caps []uintptr, capsRequested, boundingSetNarrowed, noNewPrivs bool) error {
+	if uid >= 0 {
+		if got := unix.Getuid(); got != uid {
+			return fmt.Errorf("privdrop: uid is %d after setuid(%d)", got, uid)
+		}
+		if got := unix.Geteuid(); got != uid {
+			return fmt.Errorf("privdrop: euid is %d after setuid(%d)", got, uid)
+		}
+	}
+	if gid >= 0 {
+		if got := unix.Getgid(); got != gid {
+			return fmt.Errorf("privdrop: gid is %d after setgid(%d)", got, gid)
+		}
+	}
+	if noNewPrivs {
+		got, err := unix.PrctlRetInt(unix.PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0)
+		if err != nil {
+			return fmt.Errorf("privdrop: PR_GET_NO_NEW_PRIVS: %w", err)
+		}
+		if got != 1 {
+			return fmt.Errorf("privdrop: no_new_privileges was requested but PR_GET_NO_NEW_PRIVS is %d", got)
+		}
+	}
+	if capsRequested {
+		allowed := make(map[uintptr]bool, len(caps))
+		var want [2]uint32
+		for _, c := range caps {
+			allowed[c] = true
+			if c < 32 {
+				want[0] |= 1 << c
+			} else {
+				want[1] |= 1 << (c - 32)
+			}
+		}
+
+		// What the process actually holds now.
+		hdr := unix.CapUserHeader{Version: unix.LINUX_CAPABILITY_VERSION_3, Pid: 0}
+		var got [2]unix.CapUserData
+		if err := unix.Capget(&hdr, &got[0]); err != nil {
+			return fmt.Errorf("privdrop: capget to verify the result: %w", err)
+		}
+		for i := range got {
+			if got[i].Effective != want[i] || got[i].Permitted != want[i] {
+				return fmt.Errorf("privdrop: capabilities are %s after restricting them to %s",
+					describeCapMask(got[0].Effective, got[1].Effective), strings.Join(capabilityNames(caps), "+"))
+			}
+		}
+
+		// The ambient set is the one that matters after this: exec keeps ambient
+		// capabilities and drops everything else. Checking only permitted and
+		// effective would pass while the component ends up with none.
+		for _, c := range caps {
+			set, err := unix.PrctlRetInt(unix.PR_CAP_AMBIENT, unix.PR_CAP_AMBIENT_IS_SET, c, 0, 0)
+			if err != nil {
+				return fmt.Errorf("privdrop: PR_CAP_AMBIENT_IS_SET %s: %w", capabilityName(c), err)
+			}
+			if set != 1 {
+				return fmt.Errorf("privdrop: %s is not in the ambient set, so it would not survive exec", capabilityName(c))
+			}
+		}
+
+		// The bounding set is only asserted when it could be narrowed; when it
+		// could not, no_new_privileges is what closes the hole, and that was
+		// verified above.
+		if boundingSetNarrowed {
+			for c := uintptr(0); c <= lastKnownCapability; c++ {
+				if allowed[c] {
+					continue
+				}
+				bit, err := unix.PrctlRetInt(unix.PR_CAPBSET_READ, c, 0, 0, 0)
+				if err != nil {
+					// Unknown capability on this kernel.
+					continue
+				}
+				if bit == 1 {
+					return fmt.Errorf("privdrop: %s is still in the bounding set after dropping it", capabilityName(c))
+				}
+			}
+		} else if !noNewPrivs {
+			return fmt.Errorf("privdrop: the capability bounding set was not narrowed and no_new_privileges is off, so capabilities could still be gained through execve")
+		}
+	}
+	return nil
+}
+
+// describeCapMask renders a capability bitmask for error messages.
+func describeCapMask(low, high uint32) string {
+	var caps []uintptr
+	for c := uintptr(0); c <= lastKnownCapability; c++ {
+		set := false
+		if c < 32 {
+			set = low&(1<<c) != 0
+		} else {
+			set = high&(1<<(c-32)) != 0
+		}
+		if set {
+			caps = append(caps, c)
+		}
+	}
+	if len(caps) == 0 {
+		return "none"
+	}
+	return strings.Join(capabilityNames(caps), "+")
+}

--- a/internal/runner/privdrop_test.go
+++ b/internal/runner/privdrop_test.go
@@ -1,0 +1,212 @@
+//go:build linux
+
+package runner
+
+import (
+	"os"
+	"os/user"
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+func TestCapabilityByName(t *testing.T) {
+	for _, in := range []string{"CAP_NET_RAW", "cap_net_raw", "net_raw", "  NET_RAW  ", "Cap_Net_Raw"} {
+		got, err := capabilityByName(in)
+		if err != nil {
+			t.Errorf("capabilityByName(%q) errored: %v", in, err)
+			continue
+		}
+		if name := capabilityName(got); name != "CAP_NET_RAW" {
+			t.Errorf("capabilityByName(%q) resolved to %s, want CAP_NET_RAW", in, name)
+		}
+	}
+	for _, bad := range []string{"", "   ", "CAP_MAKE_COFFEE", "SYS_ADMINISTRATOR", "CAP_"} {
+		if _, err := capabilityByName(bad); err == nil {
+			t.Errorf("capabilityByName(%q) accepted an unknown capability; a typo must not silently widen or narrow confinement", bad)
+		}
+	}
+}
+
+func TestCapMask(t *testing.T) {
+	// CAP_CHOWN is 0, CAP_NET_BIND_SERVICE is 10, CAP_BPF is 39 (second word).
+	chown, _ := capabilityByName("CAP_CHOWN")
+	bind, _ := capabilityByName("CAP_NET_BIND_SERVICE")
+	bpf, _ := capabilityByName("CAP_BPF")
+
+	if got := capMask(nil); got != [2]uint32{0, 0} {
+		t.Errorf("capMask(nil)=%v, want an empty mask", got)
+	}
+	if got := capMask([]uintptr{chown}); got != [2]uint32{1, 0} {
+		t.Errorf("capMask(CAP_CHOWN)=%v, want {1,0}", got)
+	}
+	if got := capMask([]uintptr{bind}); got != [2]uint32{1 << 10, 0} {
+		t.Errorf("capMask(CAP_NET_BIND_SERVICE)=%v, want {0x400,0}", got)
+	}
+	if got := capMask([]uintptr{bpf}); got[1] == 0 {
+		t.Errorf("capMask(CAP_BPF)=%v, want a bit in the high word (capability %d)", got, bpf)
+	}
+}
+
+func TestResolveUser(t *testing.T) {
+	self, err := user.Current()
+	if err != nil {
+		t.Fatalf("cannot determine the current user: %v", err)
+	}
+	selfUID, _ := strconv.Atoi(self.Uid)
+	selfGID, _ := strconv.Atoi(self.Gid)
+
+	t.Run("by name", func(t *testing.T) {
+		uid, gid, _, err := resolveUser(self.Username)
+		if err != nil {
+			t.Fatalf("resolveUser(%q): %v", self.Username, err)
+		}
+		if uid != selfUID || gid != selfGID {
+			t.Errorf("got uid=%d gid=%d, want %d/%d (the user's primary group)", uid, gid, selfUID, selfGID)
+		}
+	})
+
+	t.Run("numeric uid gets the primary group from the database", func(t *testing.T) {
+		uid, gid, _, err := resolveUser(self.Uid)
+		if err != nil {
+			t.Fatalf("resolveUser(%q): %v", self.Uid, err)
+		}
+		if uid != selfUID || gid != selfGID {
+			t.Errorf("got uid=%d gid=%d, want %d/%d", uid, gid, selfUID, selfGID)
+		}
+	})
+
+	t.Run("explicit uid:gid", func(t *testing.T) {
+		uid, gid, _, err := resolveUser("4242:4243")
+		if err != nil {
+			t.Fatalf("resolveUser(4242:4243): %v", err)
+		}
+		if uid != 4242 || gid != 4243 {
+			t.Errorf("got uid=%d gid=%d, want 4242/4243", uid, gid)
+		}
+	})
+
+	t.Run("unknown uid without a group is rejected", func(t *testing.T) {
+		// A uid absent from the user database has no primary group to infer, and
+		// silently defaulting to gid 0 would hand the process root's group.
+		if _, _, _, err := resolveUser("4242"); err == nil {
+			t.Error("resolveUser(4242) accepted a uid with no database entry and no explicit gid")
+		}
+	})
+
+	for _, bad := range []string{"", "   ", ":", "definitely-not-a-user-xyz", "-1", "root:definitely-not-a-group-xyz"} {
+		if _, _, _, err := resolveUser(bad); err == nil {
+			t.Errorf("resolveUser(%q) accepted an invalid spec", bad)
+		}
+	}
+}
+
+func TestSecurityValidate(t *testing.T) {
+	self, _ := user.Current()
+
+	valid := []Security{
+		{},
+		{NoNewPrivileges: true},
+		{Capabilities: []string{}},
+		{Capabilities: []string{"CAP_NET_BIND_SERVICE", "cap_net_raw"}},
+		{User: self.Username, NoNewPrivileges: true, Capabilities: []string{"CAP_CHOWN"}},
+		{User: "4242:4243"},
+	}
+	for _, s := range valid {
+		if err := s.Validate(); err != nil {
+			t.Errorf("Validate(%+v) errored: %v", s, err)
+		}
+	}
+
+	invalid := []Security{
+		{User: "definitely-not-a-user-xyz"},
+		{Capabilities: []string{"CAP_NOT_A_THING"}},
+		{User: "4242"}, // no group to infer
+	}
+	for _, s := range invalid {
+		if err := s.Validate(); err == nil {
+			t.Errorf("Validate(%+v) accepted an unusable restriction; it must fail at apply time, not at exec time", s)
+		}
+	}
+}
+
+func TestSecurityIsZeroAndDescribe(t *testing.T) {
+	if !(Security{}).IsZero() {
+		t.Error("the zero Security must be zero")
+	}
+	// An empty capability list is a real restriction ("none"), not an absent one.
+	if (Security{Capabilities: []string{}}).IsZero() {
+		t.Error("capabilities = [] is a restriction and must not read as zero")
+	}
+	if got := (Security{Capabilities: []string{}}).describe(); got != "capabilities=none" {
+		t.Errorf("describe()=%q, want capabilities=none", got)
+	}
+	if got := (Security{User: "svc", NoNewPrivileges: true}).describe(); got != "user=svc,no_new_privileges=true" {
+		t.Errorf("describe()=%q", got)
+	}
+}
+
+// TestShimArgsRoundTrip is the contract between the two halves of the feature:
+// whatever the runner renders, the shim must parse back to the same request.
+func TestShimArgsRoundTrip(t *testing.T) {
+	self, _ := user.Current()
+	cases := []struct {
+		name string
+		sec  Security
+	}{
+		{"caps only", Security{Capabilities: []string{"CAP_NET_BIND_SERVICE"}}},
+		{"drop every capability", Security{Capabilities: []string{}}},
+		{"no new privileges only", Security{NoNewPrivileges: true}},
+		{"everything", Security{User: self.Username, NoNewPrivileges: true, Capabilities: []string{"CAP_CHOWN", "CAP_BPF"}}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			argv, err := c.sec.shimArgs("/bin/true", []string{"--flag", "value with spaces"})
+			if err != nil {
+				t.Fatalf("shimArgs: %v", err)
+			}
+			if argv[0] != PrivdropFlag {
+				t.Fatalf("argv[0]=%q, want %q", argv[0], PrivdropFlag)
+			}
+			got, err := parseShimArgs(argv[1:])
+			if err != nil {
+				t.Fatalf("the shim rejected its own arguments %v: %v", argv, err)
+			}
+			if got.command != "/bin/true" {
+				t.Errorf("command=%q, want /bin/true", got.command)
+			}
+			if !reflect.DeepEqual(got.commandArgs, []string{"--flag", "value with spaces"}) {
+				t.Errorf("commandArgs=%q, arguments must survive verbatim", got.commandArgs)
+			}
+			if got.noNewPrivs != c.sec.NoNewPrivileges {
+				t.Errorf("noNewPrivs=%v, want %v", got.noNewPrivs, c.sec.NoNewPrivileges)
+			}
+			if got.capsRequested != (c.sec.Capabilities != nil) {
+				t.Errorf("capsRequested=%v, want %v: an empty list must stay distinguishable from an absent one", got.capsRequested, c.sec.Capabilities != nil)
+			}
+			if len(got.capNames) != len(c.sec.Capabilities) {
+				t.Errorf("caps=%v, want %d entries", got.capNames, len(c.sec.Capabilities))
+			}
+			if c.sec.User != "" && got.uid != os.Getuid() {
+				t.Errorf("uid=%d, want %d", got.uid, os.Getuid())
+			}
+			if c.sec.User == "" && got.uid != -1 {
+				t.Errorf("uid=%d with no user requested, want -1 (leave it alone)", got.uid)
+			}
+		})
+	}
+}
+
+func TestParseShimArgsRejectsGarbage(t *testing.T) {
+	for _, argv := range [][]string{
+		{},                             // no command
+		{"--no-new-privs"},             // still no command
+		{"--uid=abc", "--", "/bin/sh"}, // unparseable uid
+		{"--nonsense", "--", "/bin/sh"},
+		{"--groups=1,x", "--", "/bin/sh"},
+	} {
+		if _, err := parseShimArgs(argv); err == nil {
+			t.Errorf("parseShimArgs(%q) accepted malformed input", argv)
+		}
+	}
+}

--- a/internal/runner/processrunner.go
+++ b/internal/runner/processrunner.go
@@ -113,7 +113,25 @@ func (r *ProcessRunner) Start(ctx context.Context, opts Options) (Handle, error)
 	if err := sysrt.ApplyRlimits(opts.NoFile); err != nil {
 		return nil, err
 	}
-	cmd := exec.CommandContext(ctx, opts.Command, opts.Args...)
+	command, args := opts.Command, opts.Args
+	if !opts.Security.IsZero() {
+		// Privilege restrictions have to be applied in the child, between fork
+		// and exec, so the process re-executes this binary as a shim that drops
+		// what was asked for, verifies it, and then execs the real command
+		// (keeping the same PID).
+		shimArgs, err := opts.Security.shimArgs(command, args)
+		if err != nil {
+			return nil, fmt.Errorf("component %s: %w", opts.Name, err)
+		}
+		self, err := os.Executable()
+		if err != nil {
+			return nil, fmt.Errorf("component %s: cannot locate the keystone binary to drop privileges: %w", opts.Name, err)
+		}
+		log.Printf("[runner] component=%s security=%s msg=applying privilege restrictions", opts.Name, opts.Security.describe())
+		command, args = self, shimArgs
+	}
+
+	cmd := exec.CommandContext(ctx, command, args...)
 	cmd.Env = append(os.Environ(), opts.Env...)
 	if opts.WorkingDir != "" {
 		cmd.Dir = opts.WorkingDir

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -59,6 +59,10 @@ type Options struct {
 	Command string
 	Args    []string
 	NoFile  uint64 // RLIMIT_NOFILE for processes
+	// Security restricts the privileges of a process component (user,
+	// no_new_privileges, capability allow-list). Enforced by ProcessRunner; a
+	// restriction that cannot be applied prevents the process from starting.
+	Security Security
 
 	// Container-specific fields
 	Image       string            // Container image (e.g., "docker.io/library/nginx:latest")


### PR DESCRIPTION
Fixes #11.

## What was wrong

`runner.Options` advertised `User` and `Privileged`, the container runners honoured them, and
the process runner ignored both — it only set the process group. A recipe author asking for a
restriction on a process component got a silent no-op, which is worse than not offering the
field: you believe a service is confined when it runs as unconfined root.

## Recipe surface

```toml
[lifecycle.run.security]
user = "svc:svc"                          # "user", "uid", "user:group" or "uid:gid"
no_new_privileges = true                  # PR_SET_NO_NEW_PRIVS
capabilities = ["CAP_NET_BIND_SERVICE"]   # allow-list; [] means none at all
```

Same names as the systemd unit directives they replace (`User=`, `NoNewPrivileges=`,
`AmbientCapabilities=`), so an existing unit can be copied across. Omitting `capabilities`
leaves capabilities alone; declaring it as `[]` drops them all — nil and `[]` differ on
purpose.

## How it is enforced

Dropping the capability bounding set and setting `PR_SET_NO_NEW_PRIVS` are per-process and
irreversible, so doing them in the agent would confine the agent itself and everything it
later starts. The agent instead re-executes its own binary as a shim
(`keystone --privdrop-exec …`) which reduces its privileges, verifies the outcome, and only
then `exec`s the component. `exec` preserves the PID, so supervision, metrics and
`GET /v1/components` are unchanged.

Order follows systemd's, and each step is there for a reason:

1. `PR_SET_KEEPCAPS` — otherwise the uid change wipes the permitted set.
2. Close the bounding set — needs `CAP_SETPCAP` **effective**, which `setuid` clears, so it
   has to happen before the identity switch.
3. `setgroups` (always, including to empty) → `setgid` → `setuid` — inheriting the agent's
   supplementary groups would hand over access the recipe never asked for.
4. `capset` to the allow-list, then raise those capabilities into the **ambient** set — this
   is what makes them survive `exec` of a binary without file capabilities.
5. `PR_SET_NO_NEW_PRIVS`.
6. Verify, then `exec`.

## Fail-closed, and verified against the kernel

An unconfined process is never the fallback: if any restriction cannot be applied the shim
exits non-zero and the component fails to start like any other start failure. Verification
reads the result back — `getuid`, `capget`, `PR_CAP_AMBIENT_IS_SET`, `PR_GET_NO_NEW_PRIVS` —
rather than trusting that the syscalls returned 0. That check earned its keep during
development: an early version passed every syscall but the capability never reached the
ambient set, so the component would have exec'd with nothing. Checking permitted/effective
alone did not catch it; checking ambient did.

Two cases behave deliberately:

- **Asking for a capability the agent does not hold** fails with an explanation — a process
  can only narrow its own capabilities.
- **A non-root agent cannot narrow the bounding set** (`PR_CAPBSET_DROP` needs
  `CAP_SETPCAP`). With `no_new_privileges = true` this is logged and accepted, because the
  bounding set can only be exploited by an `execve` that grants privileges, which
  `no_new_privileges` forbids. Without it the hole is real and the component is refused.

## No silent no-ops anywhere

`validateRunSecurity` runs when the plan is applied and on the restart path:

- unknown capability name, unknown user, or a bare uid with no group to infer → rejected;
- `container.user` / `container.privileged` on a **process** component → rejected, pointing at
  `[lifecycle.run.security]`;
- `[lifecycle.run.security]` on a **container** component → rejected, pointing at
  `[lifecycle.run.container]`.

## Acceptance criteria

Measured on a live agent, `/proc/<pid>/status` of the supervised component.

Root agent, `user = "nobody:nogroup"`, `no_new_privileges = true`,
`capabilities = ["CAP_NET_BIND_SERVICE"]`:

```
Uid:	65534	65534	65534	65534
Gid:	65534	65534	65534	65534
CapPrm:	0000000000000400      # 0x400 = bit 10 = CAP_NET_BIND_SERVICE, and only that
CapEff:	0000000000000400
CapBnd:	0000000000000400
CapAmb:	0000000000000400
NoNewPrivs:	1
```

- [x] **uid/gid actually applied** — 65534, supplementary groups cleared.
- [x] **capability allow-list only** — `CapBnd`/`CapEff` narrowed to the single requested one.
- [x] **`no_new_privileges` → `NoNewPrivs: 1`**.
- [x] **nothing silent** — unenforceable restrictions refuse to start the component; misplaced
      privilege fields are rejected at apply time.

Non-root agent (`capabilities = []`, `no_new_privileges = true`): `CapEff`/`CapPrm`/`CapAmb`
all zero, `NoNewPrivs: 1`, bounding set untouched with the explanatory log line — the
documented and intended outcome.

## Tests and docs

Unit tests for user resolution (name, uid, `user:group`, `uid:gid`, and the rejections),
capability name parsing, `Security.Validate`, the runner↔shim argv round-trip (including that
`[]` stays distinguishable from absent), shim argv rejection of malformed input, and
`validateRunSecurity`. Full suite green under `-race`.

`docs/security.md` gains a *Process privileges* section (enforcement order, the fail-closed
contract, both edge cases, and how to verify on a device); the controls table and the known
limitations list are updated. `configs/examples/com.keystone.confined.recipe.toml` is a
ready-made confined component.

## Not in scope

Filesystem and namespace confinement (`ProtectSystem=`, `PrivateTmp=`, mount namespaces) is
not implemented; the issue lists it as optional. Container components are still confined only
through `[lifecycle.run.container]`.
