### PR TITLE
docs: add a Hugo documentation site published to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,100 @@
+name: docs
+
+# Builds the documentation site in site/ and publishes it to GitHub Pages.
+#
+# Deploys from main only: the site documents features as released, and publishing
+# from develop would describe flags that a downloaded binary does not have yet.
+# Pull requests build the site without deploying, so a broken page is caught before
+# it is merged. Use the manual trigger to publish out of band.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'site/**'
+      - '.github/workflows/pages.yml'
+  pull_request:
+    paths:
+      - 'site/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One deployment at a time; do not cancel a running one, so a queued push waits
+# rather than leaving Pages half-updated.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+env:
+  HUGO_VERSION: '0.164.0'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # enableGitInfo needs history for last-modified dates
+
+      # The Relearn theme is a Hugo module, so the build needs Go to resolve it.
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache-dependency-path: site/go.sum
+
+      - name: Install Hugo (extended)
+        run: |
+          curl -sSL -o hugo.deb \
+            "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
+          sudo dpkg -i hugo.deb
+          hugo version
+
+      - name: Configure Pages
+        id: pages
+        if: github.event_name != 'pull_request'
+        uses: actions/configure-pages@v5
+
+      - name: Build
+        working-directory: site
+        env:
+          HUGO_ENVIRONMENT: production
+        run: |
+          # On a PR there is no Pages base URL; the relative one is enough to
+          # prove the site builds.
+          hugo --gc --minify \
+            ${{ steps.pages.outputs.base_url && format('--baseURL {0}', steps.pages.outputs.base_url) || '' }}
+
+      - name: Fail on broken internal links
+        working-directory: site
+        run: |
+          # Hugo resolves relative links at build time, so a typo becomes a link to
+          # a page that does not exist. Catch the obvious ones.
+          missing=0
+          while read -r target; do
+            [ -f "public/${target}index.html" ] || [ -f "public/${target%/}.html" ] || {
+              echo "::error::broken internal link target: ${target}"
+              missing=1
+            }
+          done < <(grep -rhoE 'href="/keystone/[a-z0-9/-]*/"' public --include='*.html' \
+                    | sed -E 's|href="/keystone/||; s|"$||' | sort -u)
+          exit $missing
+
+      - uses: actions/upload-pages-artifact@v3
+        if: github.event_name != 'pull_request'
+        with:
+          path: site/public
+
+  deploy:
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ configs/examples/*.sig
 
 # tmux session layout (local dev convenience)
 .tmuxp.yaml
+# Hugo documentation site (site/): build output and module cache
+/site/public/
+/site/resources/
+/site/.hugo_build.lock

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Why Keystone? Because edge fleets need something that is lightweight, predictabl
 
 ## Documentation
 
+📖 **[Full documentation site](https://carlosprados.github.io/keystone/)** — concepts,
+internals, security model and reference, written to be read start to finish. The
+source lives in [`site/`](site/).
+
 | Document | What it covers |
 |----------|----------------|
 | [docs/security.md](docs/security.md) | **Security model**: threat model, secure-by-default controls, auth, signing, the `--insecure-skip-verify` escape hatch, config reference |

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,37 @@
+# Documentation site
+
+The Keystone documentation site: Hugo + the
+[Relearn](https://mcshelby.github.io/hugo-theme-relearn/) theme, published to
+GitHub Pages by `.github/workflows/pages.yml`.
+
+## Local preview
+
+Requires **Hugo extended** (the theme uses SCSS) and Go, since the theme is a Hugo
+module rather than a vendored copy or a submodule.
+
+```bash
+cd site
+hugo server        # http://127.0.0.1:1313/keystone/
+```
+
+Content lives in `content/`, one directory per chapter. The sidebar order comes from
+each page's `weight`, and chapter landing pages list their children with the
+`children` shortcode.
+
+## Publishing
+
+Pushes to `main` that touch `site/**` build and deploy. Pull requests build without
+deploying, and fail on a broken internal link. The workflow can also be run
+manually (**Actions → docs → Run workflow**) to publish out of band.
+
+It deploys from `main` on purpose: the site describes released behaviour, so
+publishing straight from `develop` would document flags that a downloaded binary
+does not have yet.
+
+## Updating the theme
+
+```bash
+cd site
+hugo mod get -u github.com/McShelby/hugo-theme-relearn
+hugo --gc --minify        # check it still builds
+```

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -1,0 +1,67 @@
++++
+archetype = "home"
+title = "Keystone"
+description = "A lightweight edge orchestration agent. Processes first, containers when needed."
++++
+
+# Keystone
+
+**A small program that keeps other programs running on a machine far away.**
+
+That is the whole idea. You write down which programs a device should be running.
+Keystone reads your list, installs what is missing, starts everything in the right
+order, watches it, restarts what dies, and tells you honestly what is actually
+alive.
+
+{{% notice style="primary" title="Like you're five" %}}
+Imagine a box of toys in another city, and you cannot go there.
+
+You write a note: *"Toy train first, then the tracks, then the little station."*
+You post the note through the letterbox. Somebody inside the box reads it, takes
+each toy out in the right order, sets it up, and then watches them play. If the
+train falls over, they stand it back up. If you ask "is everything okay?", they
+look at the toys and tell you the truth — they never say "all fine" while the
+train is lying on the floor.
+
+Keystone is the somebody inside the box.
+{{% /notice %}}
+
+## Why it exists
+
+Edge devices are not cloud servers. They have little memory, sometimes no
+container runtime, flaky networks, and nobody nearby to reboot them. Keystone is
+built for that:
+
+- **Processes first, containers when needed.** A native process costs almost
+  nothing. Containers are supported when you want them, not required.
+- **One static binary.** No daemon zoo, no Kubernetes, no Python runtime.
+- **Atomic deployments with rollback.** A deployment either lands or is undone.
+- **Honest state.** If a component is dead, the API says so. This is a design
+  guarantee, not an aspiration — see [Component state](concepts/component-state/).
+- **Secure by default.** Signed artifacts and recipes, loopback-only API unless
+  you provide a token, and per-component privilege dropping.
+
+## Where to start
+
+{{% children type="list" depth="1" description="true" %}}
+
+## The shape of it in one picture
+
+```mermaid
+flowchart LR
+    OP["You<br/><small>an operator, or a fleet manager</small>"]
+    subgraph DEV["One device"]
+        AG["keystone agent"]
+        C1["database<br/><small>process</small>"]
+        C2["cache<br/><small>process</small>"]
+        C3["api<br/><small>container</small>"]
+        AG --> C1
+        AG --> C2
+        AG --> C3
+    end
+    OP -- "here is the plan<br/>(HTTP / NATS / MQTT)" --> AG
+    AG -- "here is what is really running" --> OP
+```
+
+You send a **plan**. The agent turns it into running **components**. It keeps
+answering what is true, and it keeps them alive.

--- a/site/content/basics/_index.md
+++ b/site/content/basics/_index.md
@@ -1,0 +1,11 @@
++++
+title = "Basics"
+weight = 10
++++
+
+# Basics
+
+Start here. What Keystone is, the four words you need, how to install it, and your
+first deployment on your own machine.
+
+{{% children type="flat" depth="1" description="true" %}}

--- a/site/content/basics/first-deployment.md
+++ b/site/content/basics/first-deployment.md
@@ -1,0 +1,168 @@
++++
+title = "Your first deployment"
+weight = 14
+description = "A two-component stack on your own machine, start to finish."
++++
+
+# Your first deployment
+
+Ten minutes, no devices, no containers. We will deploy two toy components with a
+dependency between them, watch them run, kill one, and watch Keystone put it back.
+
+## 1. A working directory
+
+The agent keeps its state and installed components under `runtime/` in whatever
+directory you start it from, so give it its own.
+
+```bash
+mkdir -p ~/keystone-demo/recipes && cd ~/keystone-demo
+```
+
+## 2. Two recipes
+
+`recipes/clock.toml` — a component that just keeps running:
+
+```toml
+[metadata]
+name = "clock"
+version = "1.0.0"
+
+[lifecycle.run]
+restart_policy = "always"
+
+[lifecycle.run.exec]
+command = "/bin/sh"
+args = ["-c", "while true; do date; sleep 5; done"]
+```
+
+`recipes/reporter.toml` — a component that depends on the first:
+
+```toml
+[metadata]
+name = "reporter"
+version = "1.0.0"
+
+[lifecycle.run]
+restart_policy = "always"
+
+[[dependencies]]
+name = "clock"
+
+[lifecycle.run.exec]
+command = "/bin/sh"
+args = ["-c", "while true; do echo reporting; sleep 7; done"]
+```
+
+The `[[dependencies]]` block refers to the **recipe** name `clock`. Keystone maps
+it to whichever component in the plan uses that recipe.
+
+## 3. A plan
+
+`plan.toml`:
+
+```toml
+[[components]]
+name = "clock"
+recipe = "recipes/clock.toml"
+
+[[components]]
+name = "reporter"
+recipe = "recipes/reporter.toml"
+```
+
+## 4. Start the agent
+
+```bash
+keystone --http 127.0.0.1:8080 --insecure-skip-verify
+```
+
+{{% notice style="warning" %}}
+`--insecure-skip-verify` turns off the mandatory artifact signature checks. These
+recipes have no artifacts to verify, but the flag keeps the demo friction-free.
+**Never use it on a real device** — see
+[Secure defaults](../../security/secure-defaults/).
+{{% /notice %}}
+
+## 5. Apply the plan
+
+In another terminal:
+
+```bash
+curl -X POST --data-binary @plan.toml http://127.0.0.1:8080/v1/plan/apply
+```
+
+The agent uploads and parses the plan, resolves the graph, and starts `clock`
+first, then `reporter`. The log tells the story:
+
+```
+[agent] reconcile stop_order=[] start_order=[clock reporter] no_touch=[]
+[supervisor] layer=0 components=[clock] msg=starting layer
+[supervisor] component=clock state=running
+[supervisor] layer=1 components=[reporter] msg=starting layer
+[supervisor] component=reporter state=running
+[supervisor] all components running
+```
+
+## 6. Look at what is running
+
+```bash
+curl -s http://127.0.0.1:8080/v1/components | jq
+```
+
+```json
+[
+  { "name": "clock",    "state": "running", "restarts": 0, "pid": 40211, "last_health": "unknown" },
+  { "name": "reporter", "state": "running", "restarts": 0, "pid": 40219, "last_health": "unknown" }
+]
+```
+
+`last_health` is `unknown` because neither recipe declares a health check — that
+is normal, not a problem. See [Health checks](../../internals/runners/).
+
+## 7. Break something
+
+```bash
+kill -9 40211        # the clock's PID
+sleep 3
+curl -s http://127.0.0.1:8080/v1/components | jq '.[0]'
+```
+
+```json
+{ "name": "clock", "state": "running", "restarts": 1, "pid": 41002 }
+```
+
+New PID, `restarts: 1`. The restart policy was `always`, so the runner brought it
+back. Nothing you had to do.
+
+## 8. Re-apply the same plan
+
+```bash
+curl -X POST --data-binary @plan.toml http://127.0.0.1:8080/v1/plan/apply
+curl -s http://127.0.0.1:8080/v1/components | jq '.[].pid'
+```
+
+The PIDs do **not** change. Applying an unchanged plan is a no-op: Keystone
+reconciles rather than restarts. This matters on a device you cannot afford to
+disturb. See [Reconcile and reuse](../../concepts/reconcile-and-reuse/).
+
+## 9. Stop everything
+
+```bash
+curl -X POST http://127.0.0.1:8080/v1/plan/stop
+```
+
+## Using the CLI instead
+
+Everything above works through `keystonectl` too:
+
+```bash
+keystonectl status
+keystonectl apply plan.toml
+keystonectl restart clock
+```
+
+## What to read next
+
+- [Recipes](../../concepts/recipes/) — every field you can write.
+- [How it works inside](../../internals/) — what the agent did during that apply.
+- [Security](../../security/) — what to change before this touches a real device.

--- a/site/content/basics/install.md
+++ b/site/content/basics/install.md
@@ -1,0 +1,68 @@
++++
+title = "Install"
+weight = 13
+description = "Get the binaries, or build them from source."
++++
+
+# Install
+
+Keystone is a single static binary per architecture. No runtime dependencies —
+`CGO` is disabled at build time.
+
+## From releases
+
+Grab the archive for your architecture from the
+[releases page](https://github.com/carlosprados/keystone/releases). Builds are
+published for Linux `amd64`, `arm64` and `armv7`, which covers most edge hardware
+from an industrial PC down to a Raspberry Pi.
+
+```bash
+tar xzf keystone_*_linux_arm64.tar.gz
+sudo install -m 0755 keystone keystonectl /usr/local/bin/
+keystone --version
+```
+
+{{% notice style="warning" title="Verify what you install" %}}
+Released binaries are **not signed yet** (no cosign signature, no SBOM). Until
+that lands, check the published checksums and fetch over HTTPS only. It is tracked
+as a known limitation in the [security model](../../security/).
+{{% /notice %}}
+
+## From source
+
+Requires Go 1.24+ and [Task](https://taskfile.dev/).
+
+```bash
+git clone https://github.com/carlosprados/keystone.git
+cd keystone
+task build          # builds keystone, keystonectl, keystoneserver
+task test           # go test ./...
+```
+
+`task` with no arguments lists every available target. There is no Makefile.
+
+## The three binaries
+
+| Binary | What it is for |
+|---|---|
+| `keystone` | The agent. This is what runs on the device. |
+| `keystonectl` | Command-line client. Talks to an agent over its HTTP API. |
+| `keystoneserver` | A tiny static file server, handy for serving test artifacts while you develop. |
+
+## Running it
+
+```bash
+keystone --http 127.0.0.1:8080
+```
+
+That is a working agent with the HTTP adapter on loopback. It has no plan yet, so
+it is supervising nothing.
+
+{{% notice style="note" %}}
+Binding anything other than loopback **requires** an API token — the agent refuses
+to start otherwise, rather than quietly exposing an unauthenticated control plane
+on the network. See [API authentication](../../security/api-auth/).
+{{% /notice %}}
+
+For a real deployment, run it under systemd; there is a unit example in
+[Running under systemd](../../operations/systemd/).

--- a/site/content/basics/key-ideas.md
+++ b/site/content/basics/key-ideas.md
@@ -1,0 +1,92 @@
++++
+title = "The four words"
+weight = 12
+description = "Recipe, plan, component, agent — everything else is detail."
++++
+
+# The four words
+
+Learn these four and the rest of the documentation reads easily.
+
+## Recipe
+
+**How to install and run one piece of software.** A TOML file, usually kept in
+version control next to the software it describes.
+
+```toml
+[metadata]
+name = "com.acme.api"
+version = "1.4.0"
+
+[[artifacts]]
+uri = "https://downloads.acme.com/api-1.4.0.tar.gz"
+sha256 = "9f2c…"
+sig_uri = "https://downloads.acme.com/api-1.4.0.tar.gz.sig"
+unpack = true
+
+[lifecycle.run.exec]
+command = "./api"
+args = ["--port", "8080"]
+
+[lifecycle.run.health]
+check = "http://127.0.0.1:8080/healthz"
+interval = "10s"
+
+[[dependencies]]
+name = "com.acme.database"
+```
+
+A recipe is a *class*: it describes a kind of thing. Full detail in
+[Recipes](../../concepts/recipes/).
+
+## Plan
+
+**Which recipes this device should be running, and under what names.** Also TOML,
+and deliberately tiny.
+
+```toml
+[[components]]
+name = "database"
+recipe = "recipes/com.acme.database.toml"
+
+[[components]]
+name = "api"
+recipe = "recipes/com.acme.api.toml"
+```
+
+A device has exactly one plan at a time. Sending a new one is how you deploy. See
+[Plans](../../concepts/plans/).
+
+## Component
+
+**A recipe, running, under the name the plan gave it.** A component is an
+*instance*: it has a state (`running`, `stopped`, `failed`), a PID, a restart
+count and a health verdict.
+
+The same recipe can appear twice in a plan under two names — two components, one
+recipe.
+
+## Agent
+
+**The `keystone` binary on the device.** It owns the plan, the components, and the
+truth about them. Everything else — the CLI, the REST API, the NATS and MQTT
+adapters — is a way of asking the agent to do something.
+
+## How they fit together
+
+```mermaid
+flowchart TD
+    P["plan.toml<br/><small>names + which recipe</small>"]
+    R1["recipe: database"]
+    R2["recipe: api"]
+    A["agent"]
+    C1["component 'database'<br/><small>running, pid 4021</small>"]
+    C2["component 'api'<br/><small>running, pid 4088</small>"]
+
+    P --> A
+    R1 --> A
+    R2 --> A
+    A --> C1
+    A --> C2
+    C2 -. "depends on" .-> C1
+```

--- a/site/content/basics/what-is-keystone.md
+++ b/site/content/basics/what-is-keystone.md
@@ -1,0 +1,64 @@
++++
+title = "What is Keystone?"
+weight = 11
+description = "The problem it solves, and what it deliberately is not."
++++
+
+# What is Keystone?
+
+Keystone is an **agent**: a small program that runs on a device and takes care of
+the other programs on that device.
+
+You never log into the device to start things by hand. You describe what should be
+running, and the agent makes reality match the description.
+
+{{% notice style="primary" title="Like you're five" %}}
+A **plan** is your shopping list. A **recipe** is how to make one thing on the
+list. A **component** is the thing once it is made and running. The **agent** is
+the cook who reads the list, follows each recipe, and keeps an eye on the pans.
+{{% /notice %}}
+
+## The problem
+
+You have a hundred devices in a hundred factories. Each needs a handful of
+programs: a data collector, a small database, an API, a metrics agent. They must
+start in the right order — the API is useless before the database is up. Programs
+crash. Networks drop mid-update. Nobody is on site.
+
+Doing this by hand does not scale, and the usual cloud answer (Kubernetes) is far
+too heavy for a box with 512 MB of RAM and no reliable uplink.
+
+## What Keystone does
+
+| Job | How |
+|---|---|
+| Install software | Downloads **artifacts**, checks their SHA-256 and signature, unpacks them, runs an install hook |
+| Start it in order | Builds a dependency graph and starts each layer in parallel |
+| Keep it alive | Health probes plus a restart policy per component |
+| Update safely | A new plan is reconciled: only what changed is touched, and a failed apply rolls back |
+| Report the truth | `GET /v1/components` never claims a dead component is running |
+| Survive reboots | State is persisted; on boot the agent reaps orphans and re-applies the last plan |
+| Reduce privilege | Per-component user, capability allow-list and `no_new_privileges` |
+
+## What it is not
+
+- **Not a scheduler.** Keystone does not decide *which* device runs what. It does
+  what its plan says. Placement is your fleet manager's job.
+- **Not a container platform.** It can run containers, but a container runtime is
+  optional. There is no image registry, no CNI orchestration beyond the basics, no
+  service mesh.
+- **Not multi-tenant.** One agent, one plan, one device.
+- **Not a cluster.** Devices do not talk to each other or elect leaders.
+
+That narrowness is the point: it is why a single static binary can do the job on a
+device that could never run anything bigger.
+
+## How you talk to it
+
+Three interchangeable front doors, called **adapters**, all driving the same logic:
+
+- **HTTP** — a small REST API. On by default, bound to loopback.
+- **NATS** — subject-based messaging, with an optional JetStream job queue.
+- **MQTT** — broker topics, QoS, last-will. The classic IoT choice.
+
+You can enable several at once. See [Control planes](../../control-planes/).

--- a/site/content/concepts/_index.md
+++ b/site/content/concepts/_index.md
@@ -1,0 +1,11 @@
++++
+title = "Core concepts"
+weight = 20
++++
+
+# Core concepts
+
+The model Keystone works with: what you write, what it builds from it, and the
+rules it follows when reality and your plan disagree.
+
+{{% children type="flat" depth="1" description="true" %}}

--- a/site/content/concepts/component-state.md
+++ b/site/content/concepts/component-state.md
@@ -1,0 +1,88 @@
++++
+title = "Component state"
+weight = 24
+description = "What each state means, and the liveness guarantees you can rely on."
++++
+
+# Component state
+
+`GET /v1/components` is meant to be trustworthy enough to alert on. This page is
+the contract.
+
+{{% notice style="primary" title="Like you're five" %}}
+If the toy is broken, the note that comes back says *broken*. It never says
+*"playing happily"* about a toy that is lying on the floor in pieces. Even when
+that is more embarrassing.
+{{% /notice %}}
+
+## The states
+
+| State | Meaning |
+|---|---|
+| `none` | Known from the plan; nothing installed or started yet |
+| `stopped` | Not running: never started, stopped on request, or exited cleanly with no applicable restart policy |
+| `running` | A managed instance is alive **and supervised** |
+| `failed` | Terminal: crashed with no applicable restart policy, or exhausted `max_retries` |
+
+The supervisor also has transient states — `installing`, `starting`, `stopping` —
+which appear in the log as `[supervisor] component=… state=…`. They are *not*
+published for plan components: as far as the API is concerned a component goes from
+`none` to `running` (or `failed`). Only the `--demo` stack publishes raw supervisor
+states.
+
+`last_health` is `healthy`, `unhealthy` or `unknown`. Only components that declare
+`[lifecycle.run.health]` ever get a verdict; the rest stay `unknown` forever, which
+is not a problem.
+
+## The guarantees
+
+These hold at every write path — the runner's exit callback, an explicit stop, and
+the periodic state poller:
+
+- A component reported `running` **has a live supervision loop**: its health probe
+  and restart policy are active.
+- A component reported `running` with `pid > 0` **has that PID alive**. Keystone
+  never advertises a PID that no longer exists; when a process is gone the PID is
+  cleared to `0` and the state moves to `stopped` or `failed`.
+- **Every exit updates the state, including a clean one.** A process that traps
+  `SIGTERM` and shuts down gracefully under `restart_policy = "on-failure"` is
+  reported `stopped`, not left at its last good state.
+- `last_health` is reset to `unknown` when a component exits. Something that is
+  gone cannot still be healthy.
+- A failed apply unwinds through the same teardown as an explicit stop, so a
+  component the agent gave up on does not linger as `running`.
+
+{{% notice style="note" title="Containers are the exception" %}}
+Container components report `pid = 0` — there is no host PID to probe — so for them
+the supervision loop is the only liveness signal available. A container that dies
+while its loop is alive can still read `running`. This is tracked as
+[issue #13](https://github.com/carlosprados/keystone/issues/13).
+{{% /notice %}}
+
+## Why this is spelled out
+
+These guarantees exist because they were once absent. In production, an InfluxDB
+component was killed during a re-apply; the agent kept advertising it as
+`running` / `healthy` with a PID that no longer existed, and a downstream data
+pipeline was silently broken for minutes — the alerting looked green the whole
+time.
+
+The cause was two-fold: the reconcile logic decided a component could be reused by
+reading cached state alone, and the runner's exit callback only updated the store
+when the exit was an *error*. A clean exit therefore froze the record at
+`running/healthy` forever, which then made the corpse look like a valid candidate
+for reuse.
+
+Both are fixed
+([#10](https://github.com/carlosprados/keystone/issues/10)), and the rules above
+are what the fix guarantees. The lesson generalises: **cached state is not
+liveness**. Ask the kernel.
+
+## Watching it
+
+```bash
+watch -n1 'curl -s localhost:8080/v1/components | jq -r ".[] | \"\(.name) \(.state) pid=\(.pid) \(.last_health)\""'
+```
+
+Prometheus metrics carry the same information for alerting — see
+[Metrics](../../operations/metrics/).

--- a/site/content/concepts/dependencies.md
+++ b/site/content/concepts/dependencies.md
@@ -1,0 +1,102 @@
++++
+title = "Dependencies"
+weight = 23
+description = "Start order, restart cascades, and the three dependency types."
++++
+
+# Dependencies
+
+Dependencies do two separate jobs, and Keystone lets you pick them independently:
+
+1. **Ordering** — who starts before whom.
+2. **Cascading** — who gets restarted when something they depend on restarts.
+
+{{% notice style="primary" title="Like you're five" %}}
+The tracks must be laid before the train can run: that is *ordering*.
+
+If someone rebuilds the tracks, the train has to stop and start again: that is
+*cascading*.
+
+Sometimes you rebuild the tracks and the train genuinely does not care. Then you
+want ordering without cascading.
+{{% /notice %}}
+
+## The three types
+
+```toml
+[[dependencies]]
+name = "com.acme.database"
+version = ">=2.0.0"
+type = "hard"
+```
+
+| Type | Must exist in the plan | Cascades restarts | Use it when |
+|---|---|---|---|
+| `hard` *(default)* | yes | yes | Your component holds a connection or state that breaks when the dependency restarts |
+| `soft` | no | yes | The dependency is optional on some devices, but if it is there you want the cascade |
+| `ordering` | yes | no | Start order matters, but your component reconnects on its own |
+
+An empty or missing `type` means `hard`, for backwards compatibility.
+
+## Version constraints
+
+`version` accepts standard semver constraints (`>=2.0.0`, `^1.2`, `~1.4.0`). The
+constraint is checked against the dependency's `metadata.version`:
+
+- **`hard` / `ordering`:** an unsatisfied constraint fails the apply.
+- **`soft`:** an unsatisfied constraint logs a line and the dependency is ignored.
+
+## Layers, not a chain
+
+The graph is turned into **layers**. Everything in a layer starts in parallel;
+the next layer waits for the previous one to be ready.
+
+```mermaid
+flowchart LR
+    subgraph L0["layer 0"]
+        DB["database"]
+        BR["broker"]
+    end
+    subgraph L1["layer 1"]
+        API["api"]
+        ING["ingest"]
+    end
+    subgraph L2["layer 2"]
+        UI["dashboard"]
+    end
+    DB --> API
+    DB --> ING
+    BR --> ING
+    API --> UI
+```
+
+Here `database` and `broker` start together, then `api` and `ingest` together, then
+`dashboard`. On a four-core device that is a real difference from a naive
+sequential start.
+
+A cycle in the graph is a hard error: the apply is refused with
+`cycle detected in component graph`.
+
+## What "ready" means
+
+A layer is done when every component in it is ready, and *ready* depends on the
+recipe:
+
+- **No health check:** ready as soon as the process is spawned or the container is
+  created.
+- **With a health check:** ready when the probe first reports healthy.
+
+If a component never becomes ready, its readiness times out (derived from the
+health interval and threshold), the layer fails, and the apply rolls back.
+
+## Restart cascades in practice
+
+`keystonectl restart database` on the graph above, with `hard` edges everywhere,
+restarts `database`, then `api` and `ingest`, then `dashboard` — in dependency
+order. Change `dashboard`'s dependency to `ordering` and it is left running.
+
+To see what a restart would touch without doing it:
+
+```bash
+curl -s -X POST "http://127.0.0.1:8080/v1/components/database:restart?dry=true" | jq
+```

--- a/site/content/concepts/plans.md
+++ b/site/content/concepts/plans.md
@@ -1,0 +1,118 @@
++++
+title = "Plans"
+weight = 22
+description = "The device's desired state, and how applying one works."
++++
+
+# Plans
+
+A plan is the list of components a device should be running. It is deliberately
+almost empty of logic — all the detail lives in the recipes.
+
+```toml
+[[components]]
+name = "database"
+recipe = "recipes/com.acme.database.toml"
+
+[[components]]
+name = "api"
+recipe = "recipes/com.acme.api.toml"
+
+[[components]]
+name = "metrics"
+recipe = "com.acme.telegraf:1.2.0"     # from the agent's recipe store
+```
+
+- `name` is the component name — how you will refer to it in the API and the logs.
+- `recipe` is either a **path** to a TOML file or a **`name:version`** reference to
+  a recipe already in the agent's store (uploaded via `POST /v1/recipes`).
+
+## Applying a plan
+
+```bash
+curl -X POST --data-binary @plan.toml http://127.0.0.1:8080/v1/plan/apply
+keystonectl apply plan.toml                       # same thing
+```
+
+You upload the plan's **content**. Asking the agent to read a path of its own
+(`{"planPath": …}`) is rejected: it would let anyone who can reach the API read
+arbitrary files from the device.
+
+To preview without touching anything:
+
+```bash
+curl -X POST --data-binary @plan.toml "http://127.0.0.1:8080/v1/plan/apply?dry=true"
+```
+
+A dry run logs the stop, start and no-touch sets and updates the reported plan
+status to `dry-run`, but installs and starts nothing.
+
+## What an apply actually does
+
+```mermaid
+flowchart TD
+    A["plan arrives"] --> B["load and validate<br/>every recipe"]
+    B --> C["verify recipe signatures"]
+    C --> D["build the dependency graph"]
+    D --> E["compare with the running plan<br/><small>reconcile</small>"]
+    E --> F["stop what must go<br/><small>reverse dependency order</small>"]
+    F --> G["download + verify artifacts"]
+    G --> H["run install hooks"]
+    H --> I["start layer by layer<br/><small>parallel within a layer</small>"]
+    I --> J{"did every layer<br/>come up?"}
+    J -- yes --> K["plan status: running"]
+    J -- no --> L["unwind, then roll back<br/>to the previous plan"]
+```
+
+The reconcile step is what makes re-applying cheap: unchanged components that are
+alive and supervised are left completely alone. See
+[Reconcile and reuse](../reconcile-and-reuse/).
+
+## Plan status
+
+```bash
+curl -s http://127.0.0.1:8080/v1/plan/status | jq
+```
+
+| Status | Meaning |
+|---|---|
+| `idle` | No plan has been applied |
+| `applying` | An apply is in flight |
+| `running` | The last apply succeeded |
+| `failed` | The last apply failed (and rolled back, if it could) |
+| `dry-run` | The last operation was a preview |
+| `stopped` | Someone called `/v1/plan/stop` |
+
+Only one apply runs at a time; a second concurrent request is rejected rather than
+queued.
+
+## Rollback
+
+If any layer fails to come up, the agent stops what it started and re-applies the
+**previous** plan. You end up back where you were, with an error explaining why:
+
+```
+apply failed and rollback was completed: api start: start readiness timeout
+```
+
+If the rollback itself fails you get both errors, and the plan status is `failed`.
+
+## Stopping
+
+```bash
+curl -X POST http://127.0.0.1:8080/v1/plan/stop
+```
+
+Components are stopped in reverse dependency order, and the plan status becomes
+`stopped` — which the agent takes as an explicit instruction, so it will **not**
+resume that plan on the next boot.
+
+## The graph endpoint
+
+```bash
+curl -s http://127.0.0.1:8080/v1/plan/graph | jq
+```
+
+Returns the nodes, the edges and the topological start order — useful for
+rendering, and for checking that your `[[dependencies]]` blocks say what you
+meant.

--- a/site/content/concepts/recipes.md
+++ b/site/content/concepts/recipes.md
@@ -1,0 +1,207 @@
++++
+title = "Recipes"
+weight = 21
+description = "The complete recipe format, field by field."
++++
+
+# Recipes
+
+A recipe describes **one piece of software**: where to get it, how to install it,
+how to run it, how to tell whether it is healthy, and what it needs from other
+components.
+
+{{% notice style="primary" title="Like you're five" %}}
+A recipe is a cooking recipe. It says what to buy (artifacts), how to prepare it
+(install), how to cook it (run), how to tell it is done (health), and what else
+must be ready first (dependencies).
+{{% /notice %}}
+
+## Metadata
+
+```toml
+[metadata]
+name = "com.acme.api"        # required, unique; reverse-DNS is the convention
+version = "1.4.0"            # required, semver
+description = "Acme HTTP API"
+publisher = "Acme Ltd"
+type = ""                     # reserved
+```
+
+`name` and `version` together are the recipe's **identity**. Keystone uses that
+identity, plus a digest of the file, to decide whether a component changed when you
+re-apply a plan.
+
+## Artifacts
+
+Files to download before the component can run.
+
+```toml
+[[artifacts]]
+uri = "https://downloads.acme.com/api-1.4.0.tar.gz"
+sha256 = "9f2c8b1e…"                                     # required
+sig_uri = "https://downloads.acme.com/api-1.4.0.tar.gz.sig"
+cert_uri = "https://downloads.acme.com/signing-leaf.pem" # optional
+unpack = true                                            # extract into the workdir
+github_token = ""                                        # for private GitHub assets
+
+[artifacts.headers]
+Accept = "application/octet-stream"
+```
+
+Downloads resume, retry with backoff, and are cached under
+`runtime/artifacts/<name>/<version>/`. **Both the SHA-256 and the signature are
+mandatory** unless the agent runs with `--insecure-skip-verify`. Details in
+[Artifacts](../../internals/artifacts/).
+
+## Lifecycle: install
+
+```toml
+[lifecycle.install]
+script = "chmod +x ./api && ./api --migrate"
+require_privilege = false
+```
+
+A shell script run once in the component's working directory
+(`runtime/components/<name>/<version>/`). A marker file makes it idempotent: it
+will not run again on the next apply unless the version changes.
+
+## Lifecycle: run
+
+```toml
+[lifecycle.run]
+type = "process"              # "process" (default) or "container"
+restart_policy = "always"     # "always" | "on-failure" | "never"
+max_retries = 5               # 0 = the default of 5 for always/on-failure
+
+[lifecycle.run.exec]
+command = "./api"             # "./" is relative to the working directory
+args = ["--port", "8080"]
+working_dir = ""              # defaults to the component workdir
+
+[lifecycle.run.exec.env]
+LOG_LEVEL = "info"
+```
+
+Restart policies:
+
+| Policy | Behaviour |
+|---|---|
+| `always` | Restart on any exit, and also when the health probe fails past its threshold |
+| `on-failure` | Restart only on a non-zero exit. A clean exit is left alone (the component becomes `stopped`) |
+| `never` | Never restart |
+
+Restarts back off exponentially (1 s doubling to 60 s, ±25 % jitter) so a
+crash-looping component cannot saturate the device.
+
+## Lifecycle: run, in a container
+
+```toml
+[lifecycle.run]
+type = "container"
+
+[lifecycle.run.container]
+image = "docker.io/library/nginx:1.27"
+runtime = "auto"             # auto | containerd | cli | nerdctl | docker | podman
+pull_policy = "if-not-present"
+network_mode = "bridge"
+user = "1000:1000"
+privileged = false
+hostname = "web"
+
+[[lifecycle.run.container.mounts]]
+source = "/srv/www"
+target = "/usr/share/nginx/html"
+read_only = true
+
+[[lifecycle.run.container.ports]]
+host_port = 8080
+container_port = 80
+
+[lifecycle.run.container.resources]
+memory_mb = 256
+cpu_quota = 50000
+pids_limit = 128
+```
+
+See [Containers](../../internals/runners/) for how the runtime is chosen.
+
+## Lifecycle: health
+
+```toml
+[lifecycle.run.health]
+check = "http://127.0.0.1:8080/healthz"   # http:// | tcp:// | cmd:…
+interval = "10s"
+timeout = "2s"
+failure_threshold = 3
+```
+
+Declaring a health check changes two things: the component is only considered
+*ready* when it first probes healthy, and it is only eligible for reuse on a
+re-apply while it is healthy.
+
+Without a health check, `last_health` stays `unknown` forever. That is expected.
+
+## Lifecycle: shutdown
+
+```toml
+[lifecycle.shutdown]
+script = "./api --drain"
+```
+
+Best-effort hook run when the component is stopped. Failures are logged, not
+fatal.
+
+## Security
+
+Process components only. The equivalent of a systemd unit's `User=`,
+`NoNewPrivileges=` and `AmbientCapabilities=`:
+
+```toml
+[lifecycle.run.security]
+user = "svc:svc"
+no_new_privileges = true
+capabilities = ["CAP_NET_BIND_SERVICE"]
+```
+
+Anything declared here is enforced or the component refuses to start. Full
+semantics in [Process privileges](../../security/process-privileges/).
+
+## Resources
+
+```toml
+[resources]
+open_files = 4096      # RLIMIT_NOFILE, enforced
+memory_limit = "256M"  # placeholder, not enforced for processes yet
+cpu_quota = 50000      # placeholder, not enforced for processes yet
+```
+
+{{% notice style="warning" %}}
+For **process** components only `open_files` is enforced today. Memory and CPU
+limits are honoured for containers, through
+`[lifecycle.run.container.resources]`.
+{{% /notice %}}
+
+## Dependencies
+
+```toml
+[[dependencies]]
+name = "com.acme.database"   # another recipe's metadata.name
+version = ">=2.0.0"          # optional semver constraint
+type = "hard"                # hard (default) | soft | ordering
+```
+
+| Type | Must be in the plan? | Restarted when the dependency restarts? |
+|---|---|---|
+| `hard` | yes | yes |
+| `soft` | no | yes, if present |
+| `ordering` | yes | no |
+
+`ordering` is the one people forget: use it when B must *start* after A but does
+not care if A is later restarted. See [Dependencies](../dependencies/).
+
+## Signing
+
+A recipe loaded from a file must carry a detached signature
+(`<recipe>.toml.sig`) verifiable against the trust bundle, checked **before any
+hook runs**. Recipes pushed through the authenticated API are trusted by that
+authentication instead. See [Signing](../../security/signing/).

--- a/site/content/concepts/reconcile-and-reuse.md
+++ b/site/content/concepts/reconcile-and-reuse.md
@@ -1,0 +1,88 @@
++++
+title = "Reconcile and reuse"
+weight = 25
+description = "Why re-applying a plan does not restart your stack."
++++
+
+# Reconcile and reuse
+
+Applying a plan is a **reconcile**, not a restart. Keystone compares what you want
+with what is running and touches as little as possible.
+
+{{% notice style="primary" title="Like you're five" %}}
+You hand in a new shopping list. Most of it is the same as last time, and those
+things are already in the cupboard — so nobody goes shopping for them again. Only
+the new and changed items get fetched.
+
+But before ticking something off as "already in the cupboard", the cook actually
+looks in the cupboard.
+{{% /notice %}}
+
+## The three buckets
+
+Every component in the new plan lands in exactly one bucket:
+
+| Bucket | When | What happens |
+|---|---|---|
+| **start** | New, or its recipe changed, or it is not healthy/alive | Stopped if running, then installed and started fresh |
+| **stop** | In the old plan, not in the new one | Stopped, in reverse dependency order |
+| **no_touch** | Unchanged, alive, supervised, healthy | Left running, untouched — same PID |
+
+The reconcile decision appears in the log on every apply:
+
+```
+[agent] reconcile stop_order=[legacy-agent] start_order=[api] no_touch=[database broker]
+```
+
+## What counts as "changed"
+
+A component is considered changed when its **recipe identity**
+(`metadata.name:metadata.version`) or the **digest of the recipe file** differs
+from what was recorded for the running plan.
+
+So editing a recipe in place — same version, different content — *does* trigger a
+restart. That is deliberate: the digest is what tells the agent your intent
+changed. If the previous digest is unknown (an older state file), the agent
+conservatively restarts once.
+
+Restarts then cascade to dependents according to each edge's
+[dependency type](../dependencies/).
+
+## Reuse has preconditions
+
+A component is kept running only when **all** of these hold:
+
+1. it is reported `running`;
+2. it has a **live supervision loop**;
+3. its **process is alive** (for process components, by probing the PID);
+4. it is **healthy**, if the recipe declares a health check.
+
+Point 2 is the subtle one. A reused component gets no new supervision loop —
+whatever restart policy and health probe it has must *already* be attached.
+Adopting a component nobody is watching produces exactly the failure this design
+is meant to prevent: something reported as running, with no probe, no restart
+policy, and no one to notice it died.
+
+The check runs **twice**: once when the reconcile is planned, and again immediately
+before the stack starts. A component can die in between — that window is precisely
+what caused the production incident described in
+[Component state](../component-state/). When the second check revokes a reuse, the
+previous instance is torn down first, then a fresh one is started:
+
+```
+[agent] component=api msg=reusing existing running instance (no restart)
+[agent] component=cache msg=reuse revoked, starting a fresh instance
+```
+
+## Why you should care
+
+On a device you cannot afford to disturb, this is the difference between a config
+tweak and an outage. Re-applying an unchanged plan is genuinely free:
+
+```bash
+keystonectl apply plan.toml     # PIDs unchanged, restart counters unchanged
+```
+
+Which means a fleet manager can safely re-assert the desired state on a schedule —
+every hour, every boot, after every network partition — without churning
+workloads. Convergence loops need that property.

--- a/site/content/control-planes/_index.md
+++ b/site/content/control-planes/_index.md
@@ -1,0 +1,26 @@
++++
+title = "Control planes"
+weight = 50
++++
+
+# Control planes
+
+Three ways to drive the same agent. They are **adapters** over one shared
+`CommandHandler`, so any of them can do anything the others can — no feature drifts
+between transports.
+
+| Adapter | Best for | On by default |
+|---|---|---|
+| [HTTP](http/) | Local management, debugging, Prometheus | yes (loopback) |
+| [NATS](nats/) | Large fleets, cloud, offline queueing with JetStream | no |
+| [MQTT](mqtt/) | IoT platforms, constrained devices, existing brokers | no |
+
+You can run several at once — HTTP on loopback for local debugging while MQTT
+carries fleet commands is a common combination:
+
+```bash
+keystone --http 127.0.0.1:8080 \
+         --mqtt-broker tls://broker.acme.com:8883 --mqtt-device-id edge-001
+```
+
+{{% children type="flat" depth="1" description="true" %}}

--- a/site/content/control-planes/http.md
+++ b/site/content/control-planes/http.md
@@ -1,0 +1,72 @@
++++
+title = "HTTP"
+weight = 51
+description = "The REST API, endpoint by endpoint."
++++
+
+# HTTP
+
+On by default, bound to `127.0.0.1:8080`. Disable it with `--http ""`.
+
+See [API authentication](../../security/api-auth/) before exposing it off-device —
+the agent will refuse a non-loopback bind without a token.
+
+## Endpoints
+
+| Method | Path | Does |
+|---|---|---|
+| `GET` | `/healthz` | Agent liveness. Exempt from auth |
+| `GET` | `/metrics` | Prometheus metrics |
+| `GET` | `/v1/components` | Every component with state, PID, restarts, health |
+| `GET` | `/v1/plan/status` | Plan path, status, last error |
+| `GET` | `/v1/plan/graph` | Nodes, edges and topological start order |
+| `POST` | `/v1/plan/apply` | Apply a plan (body = plan TOML). `?dry=true` to preview |
+| `POST` | `/v1/plan/stop` | Stop every component |
+| `GET` | `/v1/recipes` | List recipes in the store |
+| `POST` | `/v1/recipes` | Add a recipe (body = recipe TOML) |
+| `DELETE` | `/v1/recipes/{name}/{version}` | Remove a recipe from the store |
+| `POST` | `/v1/components/{name}:stop` | Stop one component |
+| `POST` | `/v1/components/{name}:restart` | Restart one component, cascading per dependency type |
+
+## Examples
+
+```bash
+# What is running
+curl -s localhost:8080/v1/components | jq
+
+# Apply a plan (content, not a path)
+curl -X POST --data-binary @plan.toml localhost:8080/v1/plan/apply
+
+# Preview a plan
+curl -X POST --data-binary @plan.toml "localhost:8080/v1/plan/apply?dry=true"
+
+# Restart one component and wait until it is healthy again
+curl -X POST "localhost:8080/v1/components/api:restart?wait=health&timeout=60s"
+
+# With a token
+curl -H "Authorization: Bearer $KEYSTONE_API_TOKEN" https://device/v1/plan/status
+```
+
+The restart endpoint takes `wait=pid` (default — return once a new PID exists) or
+`wait=health` (return once it probes healthy), and `dry=true` to see what a restart
+would cascade to without doing it.
+
+## keystonectl
+
+The same API with less typing:
+
+```bash
+keystonectl status
+keystonectl apply plan.toml
+keystonectl restart api --wait health
+keystonectl stop api
+```
+
+It reads `KEYSTONE_API_TOKEN` from the environment and takes `--addr` for a remote
+agent.
+
+## Bruno collection
+
+`bruno/` in the repository is a ready-made [Bruno](https://www.usebruno.com/)
+collection with every request above, which beats hand-writing curl while you are
+exploring.

--- a/site/content/control-planes/mqtt.md
+++ b/site/content/control-planes/mqtt.md
@@ -1,0 +1,70 @@
++++
+title = "MQTT"
+weight = 53
+description = "Topics, QoS, and last-will for presence."
++++
+
+# MQTT
+
+The classic IoT transport, and usually the one already deployed. Works with any
+MQTT 3.1.1 broker — Mosquitto, EMQX, HiveMQ, AWS IoT Core, Azure IoT Hub.
+
+```bash
+keystone --mqtt-broker tls://broker.acme.com:8883 --mqtt-device-id edge-001
+```
+
+## Topics
+
+Everything under `keystone/{deviceId}/`:
+
+| Direction | Topic | Purpose |
+|---|---|---|
+| agent subscribes | `keystone/{deviceId}/cmd/+` | `apply`, `stop`, `status`, `components`, `graph`, `restart`, `stop-comp`, `health`, `recipes`, `add-recipe` |
+| agent publishes | `keystone/{deviceId}/resp/+` | One response topic per command |
+| agent publishes | `keystone/{deviceId}/events/state` | Component state updates |
+| agent publishes | `keystone/{deviceId}/events/health` | Health updates |
+| agent publishes | `keystone/{deviceId}/status` | Last will: `online` / `offline` |
+
+The command/response split (rather than MQTT 5 request/response) keeps it
+compatible with 3.1.1 brokers, which is what most industrial gear speaks.
+
+## Presence via last will
+
+The agent connects with a last-will message on `keystone/{deviceId}/status`. If it
+drops off the network, the **broker** publishes `offline` on its behalf. Your fleet
+view gets device presence for free, without polling — and, crucially, it works when
+the device is unable to tell you anything itself.
+
+## QoS
+
+`--mqtt-qos` (default 1) applies to commands and responses:
+
+| QoS | Guarantee | Use when |
+|---|---|---|
+| 0 | At most once | High-frequency telemetry you can afford to lose |
+| 1 *(default)* | At least once | Commands. Handlers must tolerate a duplicate |
+| 2 | Exactly once | You need it and the broker supports it well |
+
+QoS 1 means a command can be delivered twice. That is fine here: applying the same
+plan twice is a no-op thanks to [reconcile](../../concepts/reconcile-and-reuse/) —
+the design of the apply path is what makes at-least-once delivery safe.
+
+## TLS and credentials
+
+```bash
+keystone --mqtt-broker tls://broker:8883 --mqtt-device-id edge-001 \
+         --mqtt-tls-ca /etc/keystone/ca.pem \
+         --mqtt-tls-cert /etc/keystone/device.pem \
+         --mqtt-tls-key /etc/keystone/device.key
+```
+
+Username/password (`--mqtt-user`, `--mqtt-pass`) works too. Every MQTT flag has a
+`KEYSTONE_MQTT_*` environment equivalent, which is usually how you configure it
+under systemd — see [Environment variables](../../reference/env/).
+
+## Broker ACLs are part of your security
+
+Restrict each device's credentials to its own `keystone/{deviceId}/#` subtree.
+Otherwise one compromised device can publish commands to every other device on the
+broker. As with NATS, the `planPath` rejection is not yet implemented for this
+adapter, so its ACLs are load-bearing.

--- a/site/content/control-planes/nats.md
+++ b/site/content/control-planes/nats.md
@@ -1,0 +1,86 @@
++++
+title = "NATS"
+weight = 52
+description = "Subjects, authentication and the JetStream job queue."
++++
+
+# NATS
+
+For fleets. One broker, thousands of devices, request/reply for commands and
+publish for events — plus JetStream when commands must survive a device being
+offline.
+
+```bash
+keystone --nats-url nats://broker.acme.com:4222 --nats-device-id edge-001
+```
+
+## Subjects
+
+Everything under `keystone.{deviceId}.`:
+
+**Commands** (request/reply):
+
+```
+keystone.{deviceId}.cmd.apply        keystone.{deviceId}.cmd.restart
+keystone.{deviceId}.cmd.stop         keystone.{deviceId}.cmd.stop-comp
+keystone.{deviceId}.cmd.status       keystone.{deviceId}.cmd.health
+keystone.{deviceId}.cmd.components   keystone.{deviceId}.cmd.recipes
+keystone.{deviceId}.cmd.graph        keystone.{deviceId}.cmd.add-recipe
+```
+
+**Events** (published by the agent):
+
+```
+keystone.{deviceId}.events.state     component state updates
+keystone.{deviceId}.events.health    health updates
+```
+
+Publish intervals are configurable (`--nats-state-interval`, default 10 s;
+`--nats-health-interval`, default 30 s; `0` disables).
+
+## Authentication
+
+Four mechanisms, in priority order when several are set: **NKey → creds → token →
+user/password**.
+
+```bash
+keystone --nats-url tls://broker:4222 --nats-device-id edge-001 \
+         --nats-nkey /etc/keystone/device.nk \
+         --nats-tls-ca /etc/keystone/ca.pem
+```
+
+mTLS is supported with `--nats-tls-cert` / `--nats-tls-key`, and
+`--nats-tls-verify=false` exists for testing only.
+
+## JetStream
+
+Without JetStream, a command sent to an offline device is lost. With it, commands
+are durable and delivered when the device reconnects — which is what you want for
+"roll out this plan to the fleet" when half the fleet is on a truck.
+
+```bash
+keystone --nats-url nats://broker:4222 --nats-device-id edge-001 \
+         --nats-jetstream --nats-js-stream KEYSTONE_JOBS --nats-js-workers 2
+```
+
+`--nats-js-workers` sets how many jobs are processed concurrently. Note that plan
+applies are serialised regardless: a second concurrent apply is rejected, not
+queued.
+
+## Fleet-wide patterns
+
+Because subjects carry the device ID, a fleet manager can:
+
+- target one device — `keystone.edge-001.cmd.apply`;
+- subscribe to everything — `keystone.*.events.state` for a live fleet view;
+- scope credentials per device with NATS subject permissions, so a compromised
+  device cannot command its neighbours.
+
+That last point is the reason to prefer per-device NKeys over a shared token.
+
+{{% notice style="warning" %}}
+The `planPath` rejection that protects the HTTP adapter is **not** implemented for
+NATS yet: this adapter still accepts a path, which lets an authorised publisher ask
+the agent to read a local file. Off by default, and gated by broker ACLs — but keep
+those ACLs tight.
+{{% /notice %}}

--- a/site/content/internals/_index.md
+++ b/site/content/internals/_index.md
@@ -1,0 +1,11 @@
++++
+title = "How it works inside"
+weight = 30
++++
+
+# How it works inside
+
+What the agent is made of, and what actually happens between "plan received" and
+"everything running".
+
+{{% children type="flat" depth="1" description="true" %}}

--- a/site/content/internals/architecture.md
+++ b/site/content/internals/architecture.md
@@ -1,0 +1,137 @@
++++
+title = "Architecture"
+weight = 31
+description = "The three interfaces the whole design hangs from."
++++
+
+# Architecture
+
+Keystone is small enough to hold in your head. Three interfaces carry the entire
+design.
+
+```mermaid
+flowchart TD
+    subgraph ADAPTERS["Adapters — how commands arrive"]
+        H["HTTP<br/><small>REST, :8080</small>"]
+        N["NATS<br/><small>+ JetStream</small>"]
+        M["MQTT<br/><small>QoS, LWT</small>"]
+    end
+    CH["CommandHandler<br/><small>the business contract</small>"]
+    AG["Agent<br/><small>owns plan, components, truth</small>"]
+    SUP["Supervisor<br/><small>DAG, layers, readiness</small>"]
+    subgraph RUNNERS["Runners — how workloads execute"]
+        PR["ProcessRunner"]
+        CR["ContainerRunner"]
+    end
+    ART["Artifacts<br/><small>download, verify, cache</small>"]
+    ST["State<br/><small>runtime/state</small>"]
+
+    H --> CH
+    N --> CH
+    M --> CH
+    CH --> AG
+    AG --> SUP
+    AG --> ART
+    AG --> ST
+    SUP --> PR
+    SUP --> CR
+```
+
+## Interface 1: Adapter
+
+```go
+type Adapter interface {
+    Name() string
+    Start(ctx context.Context) error
+    Stop(ctx context.Context) error
+}
+```
+
+A transport, nothing more. A `Registry` starts them all and stops them all with a
+shutdown deadline. Adding a control plane means writing one of these — it cannot
+accidentally introduce new behaviour, because all it can do is call the next
+interface.
+
+## Interface 2: CommandHandler
+
+```go
+type CommandHandler interface {
+    ApplyPlan(planPath string, dry bool) error
+    StopPlan() error
+    GetComponents() []store.ComponentInfo
+    RestartComponent(name, wait string, timeout time.Duration) (*adapter.RestartResult, error)
+    // …
+}
+```
+
+Every adapter speaks this, and `Agent` is the only implementation. This is why HTTP,
+NATS and MQTT cannot drift apart in behaviour: there is exactly one code path
+behind them.
+
+## Interface 3: Runner
+
+```go
+type Runner interface {
+    Start(ctx context.Context, opts Options) (Handle, error)
+    Stop(ctx context.Context, h Handle, timeout time.Duration) error
+    RunManaged(ctx context.Context, name string, opts Options, hc HealthConfig,
+        policy RestartPolicy, maxRetries int,
+        onStart func(Handle), onHealth func(bool), onExit func(error)) error
+}
+```
+
+`RunManaged` is where a component actually lives: it starts the workload, probes
+its health, applies the restart policy, and calls back on start, on each health
+change, and on terminal exit. It returns only when the context is cancelled or the
+component is terminally done — and when it returns, **nothing is supervising that
+component any more**, which is a fact the reconcile logic depends on.
+
+Two implementations: `ProcessRunner` (process groups and signals) and
+`ContainerRunner` (containerd, with a CLI fallback).
+
+## Wiring
+
+The whole startup, from `cmd/keystone/main.go`:
+
+```go
+Agent.New(opts)
+  → adapter.NewRegistry()
+      ├→ httpadapter.New(cfg, agent)    // unless --http ""
+      ├→ natsadapter.New(cfg, agent)    // if --nats-url
+      └→ mqttadapter.New(cfg, agent)    // if --mqtt-broker
+  → Registry.StartAll(ctx)
+  → <-signal
+  → Registry.StopAll(shutdownCtx, 10s)
+```
+
+## Package map
+
+| Package | Role |
+|---|---|
+| `internal/agent` | Top-level runtime; implements `CommandHandler`; owns reconcile |
+| `internal/adapter` | Transport abstraction and lifecycle registry |
+| `internal/adapter/{http,nats,mqtt}` | The three control planes |
+| `internal/supervisor` | Component FSM, dependency graph, layered start |
+| `internal/runner` | `ProcessRunner`, `ContainerRunner`, privilege dropping |
+| `internal/recipe` | Recipe parsing |
+| `internal/deploy` | Plan parsing |
+| `internal/artifact` | Download with resume/retry, SHA-256, signatures, cache GC |
+| `internal/store` | In-memory component and recipe stores |
+| `internal/security` | ECDSA/RSA detached signature verification |
+| `internal/state` | Snapshot persistence for crash recovery |
+| `internal/metrics` | Prometheus metrics |
+| `internal/validate` | Recipe/plan schema validation |
+| `internal/runtime` | Rlimits, PID liveness, cgroup placeholders |
+
+## On-disk layout
+
+Everything is relative to the agent's working directory:
+
+```
+runtime/
+├── artifacts/<recipe-name>/<version>/    downloaded, verified artifacts
+├── components/<recipe-name>/<version>/   working directory per component
+│   └── .installed                        marker making install idempotent
+├── recipes/                              the recipe store (API-uploaded)
+└── state/snapshot.json                   plan + component state for recovery
+```

--- a/site/content/internals/artifacts.md
+++ b/site/content/internals/artifacts.md
@@ -1,0 +1,72 @@
++++
+title = "Artifacts"
+weight = 34
+description = "Downloading, verifying and caching, on a network that drops."
++++
+
+# Artifacts
+
+An artifact is a file a component needs before it can run: a binary, a tarball, a
+config bundle. Getting them onto an edge device is its own problem — the link is
+slow, expensive and unreliable.
+
+## The download path
+
+```mermaid
+flowchart LR
+    A["artifact declared<br/>in the recipe"] --> B{"already in<br/>the cache?"}
+    B -- yes --> V["verify"]
+    B -- no --> D["download<br/><small>resume + retry with backoff</small>"]
+    D --> V
+    V --> S{"sha256 matches?"}
+    S -- no --> X["fail the apply"]
+    S -- yes --> G{"signature valid?"}
+    G -- no --> X
+    G -- yes --> U["unpack if requested"]
+    U --> W["component workdir"]
+```
+
+**Resume.** Interrupted downloads continue with a range request instead of
+starting over. On a metered link that is the difference between a successful update
+and a stalled fleet.
+
+**Retry with backoff.** Transient failures are retried; the whole operation is
+bounded by `KEYSTONE_ARTIFACT_DOWNLOAD_TIMEOUT` (default 30 m).
+
+**Headers.** Per-artifact headers let you fetch from an authenticated store, and
+`github_token` sets the right `Authorization` for private GitHub release assets.
+
+## Verification is mandatory
+
+Both the SHA-256 **and** a detached signature must be present and valid. There is
+no "warn and continue" mode: a failed check fails the apply, on both the apply and
+the restart path.
+
+The only way out is `--insecure-skip-verify`, which logs a loud warning at startup
+and exists for local development. See
+[Secure defaults](../../security/secure-defaults/).
+
+## Unpacking
+
+`unpack = true` extracts into the component's working directory, with several
+protections that matter when the archive comes off the network:
+
+- **Zip-slip containment** — entries that escape the target directory are refused.
+- **Mode stripping** — setuid, setgid and world-writable bits are removed.
+- **Size cap** — `KEYSTONE_MAX_EXTRACT_BYTES` bounds the decompressed size, so a
+  small archive cannot fill the disk.
+
+## The cache
+
+Artifacts live in `runtime/artifacts/<recipe-name>/<version>/` and are reused
+across applies — re-applying a plan downloads nothing.
+
+Two mechanisms keep it bounded:
+
+- **GC**: after a successful apply, directories not referenced by the current plan
+  are removed.
+- **Budget**: `KEYSTONE_ARTIFACT_CACHE_LIMIT_BYTES` (default 2 GiB) evicts oldest
+  first once exceeded.
+
+Version the directory, not the file: keeping `<version>` in the path is what lets a
+rollback reuse the previous artifact without downloading it again.

--- a/site/content/internals/runners.md
+++ b/site/content/internals/runners.md
@@ -1,0 +1,94 @@
++++
+title = "Runners"
+weight = 33
+description = "How processes and containers are actually started, watched and stopped."
++++
+
+# Runners
+
+A runner is the thing that makes a workload exist. Two implementations, one
+interface.
+
+## ProcessRunner
+
+The default, and the reason Keystone is viable on small hardware. A component is
+just a child process.
+
+**Process groups.** Every component is started with `Setpgid`, so signals reach the
+whole tree. A shell script that spawns children is stopped properly rather than
+leaving orphans.
+
+**Stopping.** `SIGTERM` to the process group, wait for the timeout, then `SIGKILL`,
+then a final 3 s grace. A component that ignores `SIGTERM` still dies.
+
+**Logs.** stdout and stderr are captured and streamed into the agent's log, tagged
+with the component name and stream:
+
+```
+[runner] component=api stream=stdout msg=listening on :8080
+```
+
+**Resource limits.** `RLIMIT_NOFILE` from `[resources].open_files` is applied.
+CPU and memory limits for processes are placeholders today — use a container, or a
+systemd slice, if you need them enforced.
+
+**Privilege dropping.** See [Process privileges](../../security/process-privileges/).
+
+## ContainerRunner
+
+Two paths, chosen by `[lifecycle.run.container].runtime`:
+
+| Value | Behaviour |
+|---|---|
+| `auto` *(default)* | Try containerd; fall back to a CLI |
+| `containerd` | containerd v2 client only, over its socket |
+| `cli`, `nerdctl`, `docker`, `podman` | Shell out to that CLI |
+
+The containerd path talks directly to the socket
+(`KEYSTONE_CONTAINERD_SOCKET`, namespace `KEYSTONE_CONTAINERD_NAMESPACE`) and
+manages images, snapshots and tasks itself. The CLI path is the pragmatic fallback
+for devices where Docker or Podman is already the way things are done.
+
+Container components report `pid = 0` in the API — there is no host PID that means
+anything — so their liveness signal is the supervision loop. See the caveat in
+[Component state](../../concepts/component-state/).
+
+## Health probes
+
+Three forms, all with `interval`, `timeout` and `failure_threshold`:
+
+```toml
+check = "http://127.0.0.1:8080/healthz"   # 2xx/3xx is healthy
+check = "tcp://127.0.0.1:5432"            # a successful connect is healthy
+check = "cmd:/usr/local/bin/check.sh"     # exit 0 is healthy
+```
+
+Health interacts with the restart policy:
+
+- `restart_policy = "always"` — after `failure_threshold` consecutive failures the
+  runner stops the component, which makes the exit path restart it.
+- `on-failure` / `never` — a failing probe is reported (`last_health: unhealthy`)
+  but does not by itself trigger a restart. The state is honest; the decision is
+  yours.
+
+## Restart policy and backoff
+
+```
+attempt 1 → 1s   attempt 2 → 2s   attempt 3 → 4s   …   capped at 60s
+```
+
+±25 % jitter, so a device that reboots with several crash-looping components does
+not produce a synchronised thundering herd. `max_retries` defaults to 5 for
+`always` and `on-failure`; exhausting it is terminal (`failed`).
+
+## The exit contract
+
+When a workload exits and will **not** be restarted, the runner calls back once
+with the exit error — `nil` for a clean exit. The agent treats both as terminal:
+
+- error → `failed`
+- clean → `stopped`
+
+and in both cases clears the PID, resets the health verdict, deregisters the handle
+and releases the runner. Treating a clean exit as "nothing to report" is what used
+to freeze a dead component at `running/healthy`.

--- a/site/content/internals/state-and-recovery.md
+++ b/site/content/internals/state-and-recovery.md
@@ -1,0 +1,77 @@
++++
+title = "State and recovery"
+weight = 35
+description = "What survives a reboot, and what happens when the agent is killed."
++++
+
+# State and recovery
+
+An edge device loses power. The agent gets OOM-killed. Someone pulls the plug
+mid-update. Keystone is built to come back from all three without a human.
+
+## The snapshot
+
+`runtime/state/snapshot.json` holds the plan path, the plan status, the plan's
+component mapping, and the last known state of each component (including PIDs).
+
+It is written by a single state poller — twice a second at most, and **only when
+something actually changed**. `state.Save` rewrites and renames the file on every
+call, so on flash storage an unconditional write loop is real wear for no
+information gain.
+
+Writes are atomic: a temp file, a size check, then `rename(2)`. A power cut leaves
+either the old snapshot or the new one, never a truncated one.
+
+## Boot: resume or not
+
+On startup the agent reads the snapshot and decides from the persisted plan status:
+
+| Persisted status | Resume? | Why |
+|---|---|---|
+| `running` | yes | It was running; make that true again |
+| `failed` | yes | Try again — the cause may have been transient |
+| `applying` | yes | An apply was interrupted mid-flight; re-apply from scratch |
+| *(empty)* | yes | Legacy or first run; safest default |
+| `stopped` | **no** | An operator stopped it deliberately. Respect that |
+| `dry-run` | **no** | Nothing was ever installed |
+
+Unknown future values default to resuming: silently supervising nothing is the
+worse failure.
+
+## Reaping orphans
+
+Here is the subtle part. If the agent dies *without* running its shutdown path —
+`SIGKILL`, a segfault, the OOM killer — its children survive. They get reparented
+to `init` and keep running, but the new agent has no handles for them. Ports stay
+bound, lock files stay held, and a fresh start would collide with a process nobody
+is managing.
+
+So before reconciling, the agent walks the PIDs in the snapshot and reaps the ones
+that look like orphans from its previous life:
+
+```mermaid
+flowchart TD
+    A["boot: read snapshot"] --> B{"resume this plan?"}
+    B -- no --> Z["idle"]
+    B -- yes --> C["for each recorded PID"]
+    C --> D{"is its parent PID 1?"}
+    D -- no --> E["leave it alone<br/><small>the PID was recycled</small>"]
+    D -- yes --> F["SIGTERM, wait ~2s, then SIGKILL"]
+    F --> G["reset persisted state to stopped"]
+    E --> G
+    G --> H["re-apply the plan from scratch"]
+```
+
+The parent-is-`init` test is the safety catch: a PID from a previous boot has
+almost certainly been reused by something unrelated, and killing it would be
+someone else's outage. Only an init-owned orphan is a plausible leftover.
+
+Post-crash, the snapshot's `running` states are treated as **informational, not
+authoritative** — they are reset to `stopped` before the reconcile reads them, so
+the resume starts fresh rather than adopting processes nobody supervises.
+
+## Graceful shutdown
+
+On `SIGINT`/`SIGTERM` the agent stops its adapters with a 10 s deadline and runs
+each component's shutdown hook. The plan status stays as it was, so the next boot
+resumes — a reboot is not an instruction to stop serving.

--- a/site/content/internals/supervisor.md
+++ b/site/content/internals/supervisor.md
@@ -1,0 +1,83 @@
++++
+title = "Supervisor"
+weight = 32
+description = "The state machine and the layered, parallel start."
++++
+
+# Supervisor
+
+The supervisor owns *ordering* and *readiness*. It knows nothing about processes,
+containers, artifacts or signatures — it calls hooks.
+
+## The component state machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> none
+    none --> installing: Install()
+    installing --> stopped: install hook ok
+    installing --> failed: install hook failed
+    stopped --> starting: Start()
+    starting --> running: ready signal
+    starting --> failed: start error / readiness timeout
+    running --> stopping: Stop()
+    stopping --> stopped: stop hook ok
+    running --> [*]
+```
+
+`Install` is a no-op unless the component is `none` or `stopped`, and `Start` is a
+no-op if it is already `running`. That second rule is what makes component
+**reuse** possible: a component marked as already-running has both hooks skipped
+entirely.
+
+## Layers
+
+```go
+graph := BuildGraph(components)
+layers := graph.TopoLayers()      // error if there is a cycle
+```
+
+Each layer is started with one goroutine per component, then the supervisor waits
+for the whole layer before moving on. Within a layer, install and start run
+concurrently; the install phase gets a bounded timeout
+(`KEYSTONE_INSTALL_TIMEOUT`, default 2 m) while the start phase does not — the
+runner owns that.
+
+## Readiness
+
+A component may expose a readiness channel, which the runner closes when the
+workload is genuinely up:
+
+- **without a health check** — as soon as the process is spawned;
+- **with a health check** — on the first healthy probe.
+
+`Start` waits on that channel up to a timeout derived from the health interval and
+failure threshold. Three outcomes:
+
+| Signal | Result |
+|---|---|
+| ready channel closes | `running`, next layer proceeds |
+| start-error channel fires | `failed`, layer fails immediately — no waiting out the timeout |
+| timeout expires | `failed` with `start readiness timeout` |
+
+The start-error path matters for fast feedback: a component that exits during
+startup fails the apply in milliseconds instead of stalling it for the full
+readiness timeout.
+
+## Unwinding a failed layer
+
+When a layer fails, the supervisor cancels the shared context — which ends every
+managed loop it started — and then stops what came up, in reverse layer order.
+
+Keystone's stop hook deliberately delegates to the agent's single teardown path, so
+unwinding also deregisters the handle, releases the runner and records the state.
+Stopping the process alone would leave a dead handle behind that still reads as
+`running` to the API and to the next reconcile — which is exactly the bug that made
+[#10](https://github.com/carlosprados/keystone/issues/10) possible.
+
+## Concurrency notes
+
+The bookkeeping of what has started is mutex-guarded: with two components in a
+layer, several goroutines write it at once. That was an unguarded map until
+recently — a latent `concurrent map write` panic on any plan with a wide layer, now
+covered by a test that fails under `-race` if the guard is removed.

--- a/site/content/operations/_index.md
+++ b/site/content/operations/_index.md
@@ -1,0 +1,11 @@
++++
+title = "Operations"
+weight = 60
++++
+
+# Operations
+
+Running Keystone on real devices: what to watch, what to do when something is
+wrong, and how to install it properly.
+
+{{% children type="flat" depth="1" description="true" %}}

--- a/site/content/operations/metrics.md
+++ b/site/content/operations/metrics.md
@@ -1,0 +1,81 @@
++++
+title = "Metrics and alerting"
+weight = 61
+description = "What Keystone exports, and the alerts actually worth having."
++++
+
+# Metrics and alerting
+
+Prometheus metrics on `GET /metrics`, no authentication required beyond whatever
+protects the rest of the HTTP adapter.
+
+## Exported metrics
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `keystone_component_state` | gauge | `name`, `state` | `1` for the component's current state, `0` for the others |
+| `keystone_component_state_health` | gauge | `name`, `state`, `health` | `1` for the current state+health combination |
+| `keystone_component_restarts_total` | counter | `name` | Restarts since the agent started |
+| `keystone_component_healthy` | gauge | `name` | `1` healthy, `0` unhealthy |
+| `keystone_component_cpu_percent` | gauge | `name` | CPU percent, process components only |
+| `keystone_component_memory_rss_bytes` | gauge | `name` | Resident memory, process components only |
+
+Plus the Go runtime and process collectors Prometheus adds by default.
+
+## Alerts worth having
+
+**A component is not running.** The one that matters most, and it is trustworthy
+because of the [state guarantees](../../concepts/component-state/):
+
+```yaml
+- alert: KeystoneComponentDown
+  expr: keystone_component_state{state="running"} == 0
+        unless on(name) keystone_component_state{state="running"} == 1
+  for: 2m
+  annotations:
+    summary: "{{ $labels.name }} is not running"
+```
+
+**Crash looping.** A component that restarts repeatedly is up but not well:
+
+```yaml
+- alert: KeystoneComponentFlapping
+  expr: increase(keystone_component_restarts_total[15m]) > 5
+  for: 5m
+```
+
+**Unhealthy but running.** The process is alive and failing its own probe — often
+the earliest signal of a dependency problem:
+
+```yaml
+- alert: KeystoneComponentUnhealthy
+  expr: keystone_component_healthy == 0
+  for: 5m
+```
+
+**Memory creep.** Cheap to add, and it catches the leak before the OOM killer
+does:
+
+```yaml
+- alert: KeystoneComponentMemoryGrowth
+  expr: keystone_component_memory_rss_bytes > 500e6
+  for: 30m
+```
+
+## Scraping edge devices
+
+Prometheus pulling from a fleet behind NAT usually does not work. Two options that
+do:
+
+- **Push**: a Prometheus agent or Grafana Alloy on the device with remote-write.
+- **Events**: enable the NATS or MQTT adapter and consume
+  `events.state` / `events.health` centrally. You lose PromQL over raw samples but
+  gain a view that works through NAT and survives the device being offline (via
+  JetStream or a retaining broker).
+
+## Do not alert on the agent alone
+
+`/healthz` tells you the *agent* is alive. An agent can be perfectly healthy while
+supervising nothing at all — for instance after an operator called `/v1/plan/stop`,
+which the agent deliberately remembers across reboots. Alert on component state,
+and on plan status, not just on agent liveness.

--- a/site/content/operations/systemd.md
+++ b/site/content/operations/systemd.md
@@ -1,0 +1,95 @@
++++
+title = "Running under systemd"
+weight = 63
+description = "A hardened unit, and why the agent is confined too."
++++
+
+# Running under systemd
+
+The agent should itself be a supervised, confined service. There is a hardened
+example at `configs/systemd/keystone.service`:
+
+```ini
+[Unit]
+Description=Keystone Agent
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+# The agent does not implement sd_notify; use a plain process type.
+Type=simple
+
+# Security-relevant configuration comes from an environment file:
+#   KEYSTONE_API_TOKEN=<random token>           # required for a non-loopback bind
+#   KEYSTONE_TRUST_BUNDLE=/etc/keystone/ca.pem  # CA for artifact/recipe signatures
+EnvironmentFile=/etc/keystone/keystone.env
+
+ExecStart=/opt/keystone/bin/keystone --http 0.0.0.0:8080
+Restart=on-failure
+RestartSec=3
+User=keystone
+Group=keystone
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+LimitNOFILE=65535
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Choosing the agent's own privileges
+
+This is the decision that shapes everything else, and it is a genuine trade-off.
+
+**A non-root agent** (as above) is the safer default. The cost: it cannot install
+into system paths, cannot write systemd units, cannot switch a component to another
+user, and cannot narrow a component's capability bounding set — see the
+`CAP_SETPCAP` case in [Process privileges](../../security/process-privileges/).
+
+**A root agent** can do all of that, which is often why it exists: install hooks
+that place binaries in `/usr/local/bin` or write unit files need it. If you go that
+way, confine each component individually with `[lifecycle.run.security]` — that is
+precisely the situation the feature was built for. A root agent with unconfined
+components is the worst of both worlds.
+
+{{% notice style="note" %}}
+`ProtectSystem=strict` makes the filesystem read-only apart from a few paths. The
+agent needs its working directory writable — set `WorkingDirectory=` and
+`ReadWritePaths=` accordingly, or components will fail to install with confusing
+permission errors.
+{{% /notice %}}
+
+## Working directory matters
+
+Everything the agent stores — `runtime/artifacts`, `runtime/components`,
+`runtime/state` — is relative to its working directory. Set it explicitly:
+
+```ini
+WorkingDirectory=/var/lib/keystone
+```
+
+Otherwise a change in how the service is launched silently relocates the state, and
+the agent boots as if it had never deployed anything.
+
+## Restart, but let it decide
+
+`Restart=on-failure` is right. Do not add a `systemd` timer that restarts the agent
+periodically "to be safe" — the agent already re-applies its plan on boot and
+reconciles without churn. Restarting it on a schedule just adds a window where
+nothing is supervising.
+
+## Log volume
+
+Component stdout and stderr are streamed into the agent's log, so a chatty
+component becomes agent log volume. On a device with a small journal, cap it:
+
+```ini
+[Service]
+LogRateLimitIntervalSec=30s
+LogRateLimitBurst=1000
+```

--- a/site/content/operations/troubleshooting.md
+++ b/site/content/operations/troubleshooting.md
@@ -1,0 +1,105 @@
++++
+title = "Troubleshooting"
+weight = 62
+description = "Symptoms, causes and the log line that tells you which."
++++
+
+# Troubleshooting
+
+The agent's log is designed to be greppable: `[agent]`, `[supervisor]` and
+`[runner]` prefixes, and `key=value` fields.
+
+## A component will not start
+
+Look for the reason in this order:
+
+```bash
+journalctl -u keystone | grep -E "component=<name>|layer failed"
+```
+
+| Log line | Cause | Fix |
+|---|---|---|
+| `run command not found: …` | `command` is `./x` and the artifact did not deliver it | Check `unpack`, and the path inside the archive |
+| `install script failed: exit status 1` | Your install hook | The trimmed output follows in the log |
+| `start readiness timeout` | It never became healthy in time | Raise `interval`/`failure_threshold`, or fix the probe |
+| `signature verification failed` | Artifact or recipe is unsigned or signed by an unknown key | See [Signing](../../security/signing/) |
+| `privdrop: …` | A privilege restriction could not be applied | See [Process privileges](../../security/process-privileges/) |
+| `mandatory (hard) dependency "x" not present in plan` | The recipe needs something the plan does not include | Add it, or make the dependency `soft` |
+
+## The apply failed and everything went back
+
+That is rollback working:
+
+```
+[agent] apply failed, attempting rollback to previous plan: plan.toml
+apply failed and rollback was completed: api start: start readiness timeout
+```
+
+The message names the component and the reason. Fix the recipe, apply again — you
+were never left in a half-deployed state.
+
+## A component keeps restarting
+
+```bash
+journalctl -u keystone | grep "restarts="
+```
+
+Backoff is exponential to 60 s, so a crash loop is slow rather than frantic.
+`max_retries` (default 5 for `always`/`on-failure`) is the ceiling; once exhausted
+the component goes `failed` and stays there. That is a deliberate stop, not a bug:
+a component that failed five times with backoff is not going to succeed on the
+sixth for reasons of its own.
+
+## `restart_policy = "on-failure"` and my component just stops
+
+Working as intended. A clean exit (code 0) is not a failure, so it is not
+restarted, and the component is reported `stopped` with `pid: 0`. If it should come
+back regardless, use `always`.
+
+## The state looks wrong
+
+It should not. If `GET /v1/components` ever reports `running` with a PID that does
+not exist, that is a bug worth an issue — the guarantees in
+[Component state](../../concepts/component-state/) are meant to be absolute for
+process components. Container components are the known exception
+([#13](https://github.com/carlosprados/keystone/issues/13)).
+
+To check by hand:
+
+```bash
+PID=$(curl -s localhost:8080/v1/components | jq -r '.[] | select(.name=="api") | .pid')
+ps -p "$PID" -o pid,user,cmd
+```
+
+## The agent came back and started everything again
+
+Expected: on boot the agent re-applies the last plan unless it was explicitly
+stopped. It also reaps init-owned orphans from its previous life first, so ports are
+free. See [State and recovery](../../internals/state-and-recovery/).
+
+To keep a device idle across reboots, stop the plan properly
+(`POST /v1/plan/stop`) rather than killing the agent — a `stopped` status is
+remembered, a `SIGKILL` is not.
+
+## Nothing responds on the API
+
+- Bound to loopback (the default) and you are connecting from elsewhere.
+- Non-loopback bind without `KEYSTONE_API_TOKEN`: the agent **refuses to start**.
+  Check the first lines of the log.
+- Token set but not sent: everything except `/healthz` returns 401.
+
+## Useful one-liners
+
+```bash
+# States at a glance
+curl -s localhost:8080/v1/components | jq -r '.[] | "\(.name)\t\(.state)\t\(.pid)\t\(.last_health)"'
+
+# What the last apply decided
+journalctl -u keystone | grep "reconcile stop_order"
+
+# Every reuse decision
+journalctl -u keystone | grep -E "reusing existing|reuse revoked"
+
+# Confirm a component's confinement
+grep -E 'Uid|CapEff|NoNewPrivs' /proc/$(curl -s localhost:8080/v1/components | jq -r '.[0].pid')/status
+```

--- a/site/content/reference/_index.md
+++ b/site/content/reference/_index.md
@@ -1,0 +1,11 @@
++++
+title = "Reference"
+weight = 70
++++
+
+# Reference
+
+Flags, environment variables, endpoints and the full TOML schemas. Look things up
+here; the reasoning lives in the other chapters.
+
+{{% children type="flat" depth="1" description="true" %}}

--- a/site/content/reference/api.md
+++ b/site/content/reference/api.md
@@ -1,0 +1,120 @@
++++
+title = "HTTP API"
+weight = 73
+description = "Endpoints, parameters and response shapes."
++++
+
+# HTTP API
+
+Base URL is wherever `--http` points; `127.0.0.1:8080` by default. Every endpoint
+except `/healthz` requires `Authorization: Bearer <token>` when a token is
+configured.
+
+## GET /healthz
+
+```json
+{ "status": "ok", "uptime": "4h12m3s", "closed": false, "time_utc": "2026-08-06T12:00:00Z" }
+```
+
+Exempt from authentication, and exposes no component detail — safe for a load
+balancer or a systemd health check.
+
+## GET /metrics
+
+Prometheus exposition format. See [Metrics](../../operations/metrics/).
+
+## GET /v1/components
+
+```json
+[
+  {
+    "name": "api",
+    "state": "running",
+    "restarts": 1,
+    "last_health": "healthy",
+    "pid": 40219,
+    "recipe": "recipes/com.acme.api.toml",
+    "version": "1.4.0"
+  }
+]
+```
+
+`state` is one of `none`, `stopped`, `running`, `failed`. `last_health` is
+`healthy`, `unhealthy` or `unknown`. `pid` is `0` for container components and for
+anything not running. The guarantees these fields carry are in
+[Component state](../../concepts/component-state/).
+
+## GET /v1/plan/status
+
+```json
+{ "path": "plan.toml", "status": "running", "error": "" }
+```
+
+## GET /v1/plan/graph
+
+```json
+{
+  "nodes": ["database", "api"],
+  "edges": { "database": ["api"] },
+  "order": ["database", "api"]
+}
+```
+
+`edges` maps a dependency to the components that depend on it. `order` is a valid
+start order.
+
+## POST /v1/plan/apply
+
+Body: the plan TOML. Query: `dry=true` to preview.
+
+```bash
+curl -X POST --data-binary @plan.toml localhost:8080/v1/plan/apply
+```
+
+`202 Accepted` on success, `500` with the error text on failure (including a
+rollback summary), `400` if the body is not a usable plan.
+
+{{% notice style="note" %}}
+A JSON body with `planPath` is **rejected**. Upload content — letting the API name
+a local path would turn it into a file-read primitive.
+{{% /notice %}}
+
+## POST /v1/plan/stop
+
+Stops every component in reverse dependency order and marks the plan `stopped`,
+which also means it will not be resumed on the next boot.
+
+## GET /v1/recipes
+
+Lists `name:version` entries in the agent's recipe store.
+
+## POST /v1/recipes
+
+Body: recipe TOML. Stores it so plans can refer to it as `name:version`. Recipes
+added this way are trusted through API authentication rather than a file signature.
+`?force=true` overwrites an existing version.
+
+## DELETE /v1/recipes/{name}/{version}
+
+Removes a recipe from the store. Name and version are validated against an
+allow-list — no path traversal.
+
+## POST /v1/components/{name}:stop
+
+Stops one component. Its dependents are **not** stopped.
+
+## POST /v1/components/{name}:restart
+
+| Parameter | Values | Meaning |
+|---|---|---|
+| `wait` | `pid` *(default)*, `health` | Return when a new PID exists, or when it probes healthy |
+| `timeout` | duration, e.g. `60s` | How long to wait |
+| `dry` | `true` | Report what would be restarted, change nothing |
+
+```json
+{ "name": "api", "restarted": ["api", "dashboard"], "pid": 41002, "waited": "1.2s" }
+```
+
+Dependents are restarted according to each edge's
+[dependency type](../../concepts/dependencies/) — `hard` and `soft` cascade,
+`ordering` does not.

--- a/site/content/reference/cli.md
+++ b/site/content/reference/cli.md
@@ -1,0 +1,132 @@
++++
+title = "Command-line flags"
+weight = 71
+description = "Every flag of the agent, and the keystonectl commands."
++++
+
+# Command-line flags
+
+## keystone
+
+The authoritative list is always `keystone --help` on the binary you are running.
+This is that output:
+
+```text
+Usage of /tmp/claude-1000/-home-charlie-Dropbox-Charlie-1-Projects-keystone/545b403b-58b1-4684-a5ca-8c7c5c815a78/scratchpad/ks-help:
+  -api-token string
+    	Bearer token required for the HTTP API (or KEYSTONE_API_TOKEN); required to bind a non-loopback address
+  -demo
+    	Run a built-in demo: start a mock 3-component stack
+  -http string
+    	HTTP listen address (empty to disable) (default "127.0.0.1:8080")
+  -insecure-skip-verify
+    	Disable mandatory artifact integrity checks (sha256 + signature). Dev/demo only (or KEYSTONE_INSECURE_SKIP_VERIFY=true)
+  -mqtt-broker string
+    	MQTT broker URL (empty to disable MQTT adapter)
+  -mqtt-client-id string
+    	MQTT client ID (defaults to keystone-{device-id})
+  -mqtt-device-id string
+    	Device ID for MQTT topics (required if MQTT enabled)
+  -mqtt-health-interval duration
+    	Interval for publishing health events (0 to disable) (default 30s)
+  -mqtt-pass string
+    	MQTT password
+  -mqtt-qos int
+    	Default QoS level for commands and responses (0, 1, or 2) (default 1)
+  -mqtt-state-interval duration
+    	Interval for publishing state events (0 to disable) (default 10s)
+  -mqtt-tls-ca string
+    	Path to MQTT CA certificate
+  -mqtt-tls-cert string
+    	Path to MQTT client TLS certificate
+  -mqtt-tls-key string
+    	Path to MQTT client TLS key
+  -mqtt-tls-verify
+    	Verify MQTT server TLS certificate (default true)
+  -mqtt-user string
+    	MQTT username
+  -nats-creds string
+    	Path to NATS credentials file (.creds)
+  -nats-device-id string
+    	Device ID for NATS subjects (required if NATS enabled)
+  -nats-health-interval duration
+    	Interval for publishing health events (0 to disable) (default 30s)
+  -nats-jetstream
+    	Enable JetStream for persistent job queue
+  -nats-js-stream string
+    	JetStream stream name for jobs (default "KEYSTONE_JOBS")
+  -nats-js-workers int
+    	Number of concurrent job processor workers (default 1)
+  -nats-nkey string
+    	Path to NATS NKey seed file
+  -nats-pass string
+    	NATS password
+  -nats-state-interval duration
+    	Interval for publishing state events (0 to disable) (default 10s)
+  -nats-tls-ca string
+    	Path to NATS CA certificate
+  -nats-tls-cert string
+    	Path to NATS client TLS certificate
+  -nats-tls-key string
+    	Path to NATS client TLS key
+  -nats-tls-verify
+    	Verify NATS server TLS certificate (default true)
+  -nats-token string
+    	NATS authentication token
+  -nats-url string
+    	NATS server URL (empty to disable NATS adapter)
+  -nats-user string
+    	NATS username
+  -version
+    	Print version and exit
+```
+
+### The ones you will actually use
+
+| Flag | Why |
+|---|---|
+| `--http` | Listen address. `""` disables the HTTP adapter entirely |
+| `--api-token` | Required to bind anything but loopback |
+| `--insecure-skip-verify` | Development only. Disables mandatory artifact integrity |
+| `--nats-url` / `--nats-device-id` | Enable the NATS adapter |
+| `--mqtt-broker` / `--mqtt-device-id` | Enable the MQTT adapter |
+| `--demo` | Run a built-in mock 3-component stack. Good for a first look |
+| `--version` | Print version and commit |
+
+Flags always win over the equivalent environment variable.
+
+## keystonectl
+
+```bash
+keystonectl status                     # plan status and components
+keystonectl apply plan.toml            # upload and apply a plan
+keystonectl stop                       # stop the whole plan
+keystonectl stop <component>           # stop one component
+keystonectl restart <component>        # restart one, cascading per dependency type
+keystonectl restart <component> --wait health --timeout 60s
+```
+
+`--addr` points at a remote agent; the token comes from `--token` or
+`KEYSTONE_API_TOKEN`.
+
+## keystoneserver
+
+A minimal static file server, for serving test artifacts during development:
+
+```bash
+keystoneserver --addr :9000 --root ./dist
+```
+
+## Task targets
+
+Development uses [Task](https://taskfile.dev/), not make:
+
+```bash
+task build     # all three binaries, with version ldflags
+task run       # agent with HTTP on :8080
+task dev       # live reload via air
+task test      # go test -v ./...
+task fmt       # go fmt ./...
+task vet       # go vet ./...
+task hooks     # install the go fmt pre-commit hook
+```

--- a/site/content/reference/env.md
+++ b/site/content/reference/env.md
@@ -1,0 +1,77 @@
++++
+title = "Environment variables"
+weight = 72
+description = "Every KEYSTONE_* variable, grouped by what it affects."
++++
+
+# Environment variables
+
+The agent loads a `.env` file from its working directory at startup, before
+anything else, so these can live there or in a systemd `EnvironmentFile`.
+
+**A flag always wins over its environment variable.**
+
+## Security
+
+| Variable | Default | Effect |
+|---|---|---|
+| `KEYSTONE_API_TOKEN` | — | Bearer token for the HTTP API. Required for a non-loopback bind |
+| `KEYSTONE_TRUST_BUNDLE` | — | PEM file of CAs used to verify artifact and recipe signatures |
+| `KEYSTONE_LEAF_CERT` | — | Provisioned signing leaf certificate |
+| `KEYSTONE_INSECURE_SKIP_VERIFY` | `false` | Disables mandatory artifact integrity. Development only |
+| `KEYSTONE_MAX_REQUEST_BYTES` | 4 MiB | HTTP request body cap (413 on overflow) |
+| `KEYSTONE_MAX_EXTRACT_BYTES` | — | Cap on decompressed archive size |
+
+## Artifacts
+
+| Variable | Default | Effect |
+|---|---|---|
+| `KEYSTONE_ARTIFACT_CACHE_LIMIT_BYTES` | 2 GiB | Cache budget; oldest evicted first |
+| `KEYSTONE_ARTIFACT_DOWNLOAD_TIMEOUT` | `30m` | Per-artifact download timeout. Accepts `5m`, `1h` |
+
+## Lifecycle
+
+| Variable | Default | Effect |
+|---|---|---|
+| `KEYSTONE_INSTALL_TIMEOUT` | `2m` | Bound on the install phase of a layer |
+| `KEYSTONE_DEVICE_ID` | hostname | Device identity, used by the messaging adapters |
+
+## Containers
+
+| Variable | Default | Effect |
+|---|---|---|
+| `KEYSTONE_CONTAINERD_SOCKET` | `/run/containerd/containerd.sock` | containerd endpoint |
+| `KEYSTONE_CONTAINERD_NAMESPACE` | `keystone` | containerd namespace |
+| `KEYSTONE_CONTAINER_SNAPSHOTTER` | — | Snapshotter override (e.g. `native`, `overlayfs`) |
+| `KEYSTONE_CONTAINER_REGISTRY` | — | Default registry for unqualified image names |
+| `KEYSTONE_IMAGE_VOLUME_DIR` | — | Where image volumes are materialised |
+| `KEYSTONE_CNI_CONF_DIR` | — | CNI configuration directory |
+| `KEYSTONE_CNI_PLUGIN_DIRS` | — | CNI plugin search path |
+| `KEYSTONE_CNI_NETNS_DIR` | — | CNI network namespace directory |
+
+## MQTT
+
+Every MQTT flag has an environment equivalent, which is how you normally configure
+it under systemd:
+
+| Variable | Flag |
+|---|---|
+| `KEYSTONE_MQTT_BROKER` | `--mqtt-broker` |
+| `KEYSTONE_MQTT_DEVICE_ID` | `--mqtt-device-id` |
+| `KEYSTONE_MQTT_CLIENT_ID` | `--mqtt-client-id` |
+| `KEYSTONE_MQTT_USER` / `KEYSTONE_MQTT_PASS` | `--mqtt-user` / `--mqtt-pass` |
+| `KEYSTONE_MQTT_TLS_CERT` / `_KEY` / `_CA` | the matching `--mqtt-tls-*` |
+| `KEYSTONE_MQTT_TLS_VERIFY` | `--mqtt-tls-verify` |
+| `KEYSTONE_MQTT_QOS` | `--mqtt-qos` |
+| `KEYSTONE_MQTT_STATE_INTERVAL` | `--mqtt-state-interval` |
+| `KEYSTONE_MQTT_HEALTH_INTERVAL` | `--mqtt-health-interval` |
+
+## JetStream
+
+| Variable | Effect |
+|---|---|
+| `KEYSTONE_JOBS` | JetStream stream name for the job queue |
+
+An invalid value (a non-numeric integer, an unparseable duration, a bad boolean) is
+logged and ignored rather than crashing the agent — but check your logs, because
+"ignored" means the default is in force.

--- a/site/content/reference/schemas.md
+++ b/site/content/reference/schemas.md
@@ -1,0 +1,138 @@
++++
+title = "Recipe and plan schema"
+weight = 74
+description = "Every field, its type and its default, in one place."
++++
+
+# Recipe and plan schema
+
+Both are TOML, and both are validated against a schema on load — invalid input is
+rejected, not best-effort parsed.
+
+## Plan
+
+```toml
+[[components]]
+name = "api"                       # string, required, unique in the plan
+recipe = "recipes/api.toml"        # path to a TOML file, or "name:version" from the store
+```
+
+That is the entire plan schema. Everything else is in the recipe.
+
+## Recipe
+
+### `[metadata]`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `name` | string | yes | Reverse-DNS by convention. Part of the recipe identity |
+| `version` | string | yes | Semver. Part of the recipe identity |
+| `description` | string | no | |
+| `publisher` | string | no | |
+| `type` | string | no | Reserved |
+
+### `[[artifacts]]`
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `uri` | string | — | Where to download from |
+| `sha256` | string | — | Mandatory unless `--insecure-skip-verify` |
+| `sig_uri` | string | `<uri>.sig` | Detached signature |
+| `cert_uri` | string | — | Leaf certificate, if not provisioned on the device |
+| `unpack` | bool | `false` | Extract into the working directory |
+| `github_token` | string | — | Sets `Authorization` for private GitHub assets |
+| `headers` | table | — | Extra HTTP headers for this download |
+
+### `[lifecycle.install]`
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `script` | string | — | Shell, run once in the working directory |
+| `require_privilege` | bool | `false` | Declares that it needs privilege |
+
+### `[lifecycle.run]`
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `type` | string | `process` | `process` or `container` |
+| `restart_policy` | string | `always` | `always`, `on-failure`, `never` |
+| `max_retries` | int | `5` for always/on-failure | Terminal once exhausted |
+
+### `[lifecycle.run.exec]` — process components
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `command` | string | — | Required. `./x` is relative to the working directory |
+| `args` | string list | — | |
+| `working_dir` | string | component workdir | |
+| `env` | table | — | Extra environment variables |
+
+### `[lifecycle.run.security]` — process components
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `user` | string | agent's user | `"user"`, `"uid"`, `"user:group"`, `"uid:gid"` |
+| `no_new_privileges` | bool | `false` | `PR_SET_NO_NEW_PRIVS` |
+| `capabilities` | string list | *absent* | Allow-list. `[]` means none; omitted means unchanged |
+
+### `[lifecycle.run.container]` — container components
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `image` | string | — | Required |
+| `runtime` | string | `auto` | `auto`, `containerd`, `cli`, `nerdctl`, `docker`, `podman` |
+| `pull_policy` | string | `if-not-present` | `always`, `never`, `if-not-present` |
+| `network_mode` | string | `bridge` | `host`, `bridge`, `none` |
+| `user` | string | — | `uid:gid` inside the container |
+| `privileged` | bool | `false` | |
+| `hostname` | string | — | |
+| `env`, `labels` | table | — | |
+
+`[[lifecycle.run.container.mounts]]`: `source`, `target`, `type`
+(`bind`/`volume`/`tmpfs`), `read_only`.
+
+`[[lifecycle.run.container.ports]]`: `host_ip`, `host_port`, `container_port`,
+`protocol`.
+
+`[lifecycle.run.container.resources]`: `memory_mb`, `memory_swap`, `cpu_shares`,
+`cpu_quota`, `cpu_period`, `pids_limit`.
+
+### `[lifecycle.run.health]`
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `check` | string | — | `http://…`, `tcp://…`, `cmd:…` |
+| `interval` | duration | `10s` | |
+| `timeout` | duration | `3s` | |
+| `failure_threshold` | int | `3` | |
+
+### `[lifecycle.shutdown]`
+
+| Field | Type | Notes |
+|---|---|---|
+| `script` | string | Best-effort hook on stop |
+
+### `[resources]`
+
+| Field | Type | Enforced | Notes |
+|---|---|---|---|
+| `open_files` | uint | yes | `RLIMIT_NOFILE` |
+| `memory_limit` | string | **no** | Placeholder for process components |
+| `cpu_quota` | int | **no** | Placeholder for process components |
+
+### `[[dependencies]]`
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `name` | string | — | Another recipe's `metadata.name` |
+| `version` | string | any | Semver constraint |
+| `type` | string | `hard` | `hard`, `soft`, `ordering` |
+
+## Validating before you deploy
+
+```bash
+curl -X POST --data-binary @plan.toml "localhost:8080/v1/plan/apply?dry=true"
+```
+
+A dry run loads and validates every recipe, verifies signatures and computes the
+reconcile plan — without installing or starting anything.

--- a/site/content/security/_index.md
+++ b/site/content/security/_index.md
@@ -1,0 +1,12 @@
++++
+title = "Security"
+weight = 40
++++
+
+# Security
+
+Keystone runs arbitrary software on machines you cannot physically reach. The
+security model is therefore not decoration — this chapter is the part to read
+before a device leaves your desk.
+
+{{% children type="flat" depth="1" description="true" %}}

--- a/site/content/security/api-auth.md
+++ b/site/content/security/api-auth.md
@@ -1,0 +1,64 @@
++++
+title = "API authentication"
+weight = 43
+description = "Why the agent refuses to listen on 0.0.0.0 without a token."
++++
+
+# API authentication
+
+The HTTP API can apply plans and run arbitrary install hooks. It is, in effect, a
+remote shell. It is treated accordingly.
+
+## The default is loopback
+
+```bash
+keystone                       # binds 127.0.0.1:8080
+```
+
+Nothing off-device can reach it. To expose it you must provide a token:
+
+```bash
+export KEYSTONE_API_TOKEN="$(openssl rand -hex 32)"
+keystone --http 0.0.0.0:8080
+```
+
+Without one, the agent **refuses to start**:
+
+```
+[main] failed to start adapters: refusing to start HTTP API on non-loopback
+address ":8080" without authentication: set KEYSTONE_API_TOKEN or bind to 127.0.0.1
+```
+
+This is a startup failure, not a warning, because the failure mode it prevents —
+an unauthenticated control plane reachable from the factory LAN — is
+indistinguishable from working correctly until someone finds it.
+
+## Using the token
+
+```bash
+curl -H "Authorization: Bearer $KEYSTONE_API_TOKEN" \
+     http://device:8080/v1/components
+```
+
+`keystonectl` reads `KEYSTONE_API_TOKEN` from the environment.
+
+Comparison is constant-time, so the token cannot be recovered by timing. `/healthz`
+is exempt so an unauthenticated liveness probe still works; it exposes no component
+detail.
+
+## What is still your job
+
+- **TLS.** Keystone does not terminate TLS. Put it behind a reverse proxy, or reach
+  it over a VPN or an SSH tunnel. A bearer token on plaintext HTTP over an untrusted
+  network is a token you have given away.
+- **One token per device.** A fleet-wide shared token means one compromised device
+  compromises the fleet.
+- **Rotation.** The token comes from the environment, so rotation is a config
+  change plus a restart.
+
+## Hardening the surface
+
+Already applied, no configuration needed: request bodies are capped
+(`KEYSTONE_MAX_REQUEST_BYTES`, 4 MiB default) with a 413 on overflow; header, read
+and idle timeouts defeat slowloris; and `planPath` is rejected in favour of content
+upload, so the API cannot be used to read arbitrary files off the device.

--- a/site/content/security/process-privileges.md
+++ b/site/content/security/process-privileges.md
@@ -1,0 +1,128 @@
++++
+title = "Process privileges"
+weight = 44
+description = "Per-component user, capabilities and no_new_privileges — and how they are enforced."
++++
+
+# Process privileges
+
+By default a process component inherits everything from the agent: same uid, full
+capability set, `NoNewPrivs=0`. And the agent usually **has** to run as root — it
+writes systemd units, installs into `/usr/local/bin`, touches `/etc`. So without
+this feature, every component runs as unconfined root, and any memory-safety bug in
+any of them is a full host compromise.
+
+{{% notice style="primary" title="Like you're five" %}}
+The cook has the keys to the whole house. That does not mean every helper needs
+them. Each helper gets exactly one key — the one for the cupboard they work in —
+and they are told they may never pick up another key, ever.
+{{% /notice %}}
+
+## The recipe block
+
+```toml
+[lifecycle.run.security]
+user = "svc:svc"                          # "user", "uid", "user:group" or "uid:gid"
+no_new_privileges = true                  # PR_SET_NO_NEW_PRIVS
+capabilities = ["CAP_NET_BIND_SERVICE"]   # allow-list; [] means none at all
+```
+
+These are the same names as the systemd directives they replace — `User=`,
+`NoNewPrivileges=`, `AmbientCapabilities=` — so an existing unit can be copied
+across.
+
+Two details worth knowing:
+
+- Omitting `capabilities` leaves capabilities alone. Declaring it as `[]` drops
+  **all** of them. `nil` and `[]` differ on purpose.
+- Giving only a user (`user = "svc"`) uses that user's primary group and its
+  supplementary groups, as systemd does. A bare numeric uid with no entry in the
+  user database is rejected rather than silently defaulting to group 0.
+
+**Process components only.** Containers are confined through
+`[lifecycle.run.container]`. Declaring `[lifecycle.run.security]` on a container
+component is an error, and so is setting `container.user` / `container.privileged`
+on a process component. A misplaced restriction is refused, never ignored.
+
+## How it is enforced
+
+Dropping the capability bounding set and setting `PR_SET_NO_NEW_PRIVS` are
+per-process and **irreversible**. Doing them in the agent would confine the agent
+itself and everything it ever starts afterwards.
+
+So the agent re-executes its own binary as a shim:
+
+```mermaid
+sequenceDiagram
+    participant A as agent
+    participant S as keystone --privdrop-exec
+    participant C as component
+    A->>S: fork/exec self with the restrictions as argv
+    Note over S: PR_SET_KEEPCAPS<br/>close the bounding set<br/>setgroups → setgid → setuid<br/>capset to the allow-list<br/>raise ambient caps<br/>PR_SET_NO_NEW_PRIVS
+    S->>S: verify against the kernel
+    S->>C: execve(component)
+    Note over C: same PID as the shim
+```
+
+`execve` replaces the process image, so the **PID does not change** — supervision,
+metrics and `GET /v1/components` are unaffected.
+
+### Why that order
+
+Each step is where it is for a reason:
+
+1. **`PR_SET_KEEPCAPS`** — otherwise the uid change wipes the permitted set and
+   there would be nothing left to grant.
+2. **Close the bounding set** — `PR_CAPBSET_DROP` needs `CAP_SETPCAP` in the
+   *effective* set, and `setuid` clears the effective set. It must happen first.
+3. **`setgroups` → `setgid` → `setuid`** — always set the supplementary groups,
+   including to empty. Inheriting the agent's groups (root's) would hand the
+   component access the recipe never asked for.
+4. **`capset`, then raise ambient** — the ambient set is what survives `execve` for
+   a binary without file capabilities, which is the normal case. Skipping it leaves
+   the component with nothing.
+5. **`PR_SET_NO_NEW_PRIVS`**, then verify, then exec.
+
+## Fail-closed and verified
+
+If any requested restriction cannot be applied, the shim exits non-zero and the
+component fails to start like any other start failure. An unconfined process is
+never the fallback.
+
+Verification reads the result **back from the kernel** — `getuid`, `capget`,
+`PR_CAP_AMBIENT_IS_SET`, `PR_GET_NO_NEW_PRIVS` — rather than trusting that the
+syscalls returned 0. That check earned its keep during development: an early
+version had every syscall succeed while the capability never reached the ambient
+set, so the component would have exec'd with no capabilities at all. Checking
+permitted and effective did not catch it; checking ambient did.
+
+Two cases behave deliberately:
+
+- **Asking for a capability the agent does not hold** fails with an explanation. A
+  process can only ever narrow its own capabilities.
+- **A non-root agent cannot narrow the bounding set** (`PR_CAPBSET_DROP` needs
+  `CAP_SETPCAP`). With `no_new_privileges = true` this is logged and accepted,
+  because the bounding set can only be exploited by an `execve` that grants
+  privileges — precisely what `no_new_privileges` forbids. Without it, the hole is
+  real and the component is refused.
+
+## Verify it on a device
+
+```console
+$ grep -E 'Uid|Gid|CapEff|CapBnd|CapAmb|NoNewPrivs' /proc/<pid>/status
+Uid:	65534	65534	65534	65534
+Gid:	65534	65534	65534	65534
+CapEff:	0000000000000400      # 0x400 = bit 10 = CAP_NET_BIND_SERVICE, and only that
+CapBnd:	0000000000000400
+CapAmb:	0000000000000400
+NoNewPrivs:	1
+```
+
+Do this once per confined component the first time you deploy it. The guarantee is
+only worth what you have checked.
+
+## Not covered
+
+Filesystem and namespace confinement — the equivalent of `ProtectSystem=`,
+`PrivateTmp=`, mount namespaces — is not implemented. If you need it, run the
+component as a container, or wrap it in a systemd scope.

--- a/site/content/security/secure-defaults.md
+++ b/site/content/security/secure-defaults.md
@@ -1,0 +1,88 @@
++++
+title = "Secure by default"
+weight = 41
+description = "What is locked down out of the box, and the one escape hatch."
++++
+
+# Secure by default
+
+The defaults assume a hostile network and an unattended device. Nothing needs to be
+switched on to be safe; things need to be switched *off* to be convenient.
+
+{{% notice style="primary" title="Like you're five" %}}
+The toy box is locked. It only opens for a note that has your signature on it, and
+only if the note came through the little slot at the front — not through the window.
+{{% /notice %}}
+
+## Controls at a glance
+
+| Surface | Control | Default |
+|---|---|---|
+| HTTP bind | Loopback only; a non-loopback address **requires** a token | secure |
+| HTTP auth | Bearer token, constant-time compare, `/healthz` exempt | on when a token is set |
+| Plan submission | Content upload only; a remote `planPath` is rejected | secure |
+| Request size | Capped, 413 on overflow (4 MiB default) | secure |
+| Slowloris | Read/header/idle timeouts set | secure |
+| Artifact integrity | SHA-256 **and** detached signature, mandatory | fail-closed |
+| Recipe integrity | File-loaded recipes need a valid signature before any hook runs | fail-closed |
+| Archive extraction | Zip-slip containment, setuid/world-write stripping, size cap | secure |
+| Recipe name/version | Allow-list validated, no path traversal | secure |
+| Schema | Recipe and plan schemas enforced, not best-effort | secure |
+| Process privileges | Per-component user, capability allow-list, `no_new_privileges` | inherits the agent unless declared |
+
+## Fail-closed, everywhere
+
+The recurring rule: **when a security control cannot be applied, the operation
+fails**. It never degrades to the insecure path with a warning.
+
+- An artifact whose signature does not verify fails the apply — on the restart path
+  too, not just the first install.
+- A recipe file without a valid signature is refused *before* its install hook runs,
+  because that hook is arbitrary shell.
+- A privilege restriction that cannot be enforced refuses to start the component,
+  rather than running it unconfined.
+
+Warnings get ignored; failures get fixed.
+
+## The one escape hatch
+
+```bash
+keystone --insecure-skip-verify          # or KEYSTONE_INSECURE_SKIP_VERIFY=true
+```
+
+Disables the mandatory artifact integrity policy. It logs, at startup, every time:
+
+```
+[agent] WARNING: artifact integrity verification is DISABLED
+(--insecure-skip-verify); downloaded artifacts are NOT authenticated.
+Do not use in production.
+```
+
+Use it for local development and demos. It does not disable recipe signature
+checking on file-loaded recipes, and it does not open the HTTP API.
+
+## Threat model in one paragraph
+
+Keystone assumes the **artifact store and the network are untrusted**: anything
+downloaded must prove its origin cryptographically. It assumes the **control plane
+is authenticated** — by a token over HTTP, or by broker ACLs and TLS for NATS and
+MQTT. It assumes the **local filesystem is trusted**: whoever can write
+`runtime/state` or the recipe store already owns the device. And it assumes
+**components are semi-trusted**: they can be confined, but Keystone is not a
+sandbox — a determined workload with capabilities can still hurt the host.
+
+## Known limitations
+
+Honest list, tracked as follow-ups:
+
+- **NATS/MQTT `planPath`**: the rejection is implemented for HTTP only. Those
+  adapters are off by default and rely on broker ACLs.
+- **Release signing**: published binaries are not signed yet (no cosign, no SBOM).
+- **Container confinement**: `privileged` containers and host mounts are not gated
+  by policy.
+- **Child environment**: recipe-supplied env is not stripped of `LD_PRELOAD` /
+  `LD_LIBRARY_PATH` for process workloads.
+- **State snapshot integrity**: `runtime/state` is not integrity-protected.
+
+Treat the device's local filesystem and your broker ACLs as part of the trust
+boundary until these close.

--- a/site/content/security/signing.md
+++ b/site/content/security/signing.md
@@ -1,0 +1,64 @@
++++
+title = "Signing"
+weight = 42
+description = "How trust reaches the device, and how to set it up."
++++
+
+# Signing
+
+Everything the agent installs must be traceable to a key you control. That is done
+with **detached signatures** verified against a **trust bundle** on the device.
+
+## What gets verified
+
+| Thing | Signature | When it is checked |
+|---|---|---|
+| Artifact | `sig_uri` (or `<uri>.sig`) | Before it is unpacked or used, on apply **and** restart |
+| Recipe file | `<recipe>.toml.sig` | Before any lifecycle hook runs |
+| Recipe via API | — | Trusted by the API authentication instead |
+
+The order matters for recipes: the install hook is arbitrary shell, so verifying
+after running it would be pointless.
+
+## Trust bundle
+
+Point the agent at a PEM file of CA certificates:
+
+```bash
+export KEYSTONE_TRUST_BUNDLE=/etc/keystone/trust/ca.pem
+keystone --http 127.0.0.1:8080
+```
+
+Signatures are ECDSA or RSA over the file's contents, verified against a leaf
+certificate that must chain to the bundle. The leaf can be provisioned on the
+device or fetched per artifact with `cert_uri`.
+
+## Setting it up for development
+
+The repository ships a helper that creates a throwaway CA and signs things with it:
+
+```bash
+./scripts/dev-sign.sh init                        # create a dev CA
+./scripts/dev-sign.sh recipe recipes/api.toml     # → recipes/api.toml.sig
+./scripts/dev-sign.sh artifact dist/api-1.4.0.tar.gz
+```
+
+Then run the agent with `KEYSTONE_TRUST_BUNDLE` pointing at the generated CA. See
+`configs/trust/README.md` for the long form, including how to lay this out for
+production with a real CA.
+
+{{% notice style="warning" %}}
+A dev CA is a dev CA. For real fleets the signing key belongs in an HSM or a
+CI-managed KMS, and the private key should never touch a developer laptop.
+{{% /notice %}}
+
+## Rotating
+
+The trust bundle is a file of CA certificates, so rotation is: add the new CA to
+the bundle, ship it, start signing with the new key, then remove the old CA once
+nothing signed by it remains in any plan you might roll back to.
+
+That last clause is the one people get wrong. A rollback re-applies an **older**
+plan with older artifacts — if you have already dropped the CA that signed them, the
+rollback fails closed. Keep the old CA for at least as long as your rollback
+horizon.

--- a/site/go.mod
+++ b/site/go.mod
@@ -1,0 +1,5 @@
+module github.com/carlosprados/keystone/site
+
+go 1.26.1
+
+require github.com/McShelby/hugo-theme-relearn v0.0.0-20260310200521-93d7f257d1a3 // indirect

--- a/site/go.sum
+++ b/site/go.sum
@@ -1,0 +1,2 @@
+github.com/McShelby/hugo-theme-relearn v0.0.0-20260310200521-93d7f257d1a3 h1:3ACeOWQ6bJSUsRl7eOKeSNjh6erVeVEy1cxhLoMzZQA=
+github.com/McShelby/hugo-theme-relearn v0.0.0-20260310200521-93d7f257d1a3/go.mod h1:mKQQdxZNIlLvAj8X3tMq+RzntIJSr9z7XdzuMomt0IM=

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -1,0 +1,44 @@
+baseURL = "https://carlosprados.github.io/keystone/"
+locale = "en"
+defaultContentLanguage = "en"
+title = "Keystone"
+theme = ["github.com/McShelby/hugo-theme-relearn"]
+
+# Relearn renders the tree from the content directory; keep URLs stable.
+enableGitInfo = true
+[params]
+  editURL = "https://github.com/carlosprados/keystone/edit/develop/site/content/"
+  themeVariant = ["auto", "relearn-light", "relearn-dark", "neon"]
+  disableLandingPageButton = true
+  alwaysopen = false
+  collapsibleMenu = true
+  showVisitedLinks = true
+  disableBreadcrumb = false
+  disableNextPrev = false
+  ordersectionsby = "weight"
+  titleSeparator = "|"
+
+[markup.goldmark.renderer]
+  unsafe = true
+[markup.highlight]
+  style = "github-dark"
+  noClasses = false
+  lineNumbersInTable = false
+[markup.tableOfContents]
+  startLevel = 2
+  endLevel = 3
+
+[menu]
+  [[menu.shortcuts]]
+    name = "<i class='fab fa-fw fa-github'></i> GitHub repo"
+    identifier = "ds"
+    url = "https://github.com/carlosprados/keystone"
+    weight = 10
+  [[menu.shortcuts]]
+    name = "<i class='fas fa-fw fa-tag'></i> Releases"
+    url = "https://github.com/carlosprados/keystone/releases"
+    weight = 20
+  [[menu.shortcuts]]
+    name = "<i class='fas fa-fw fa-bug'></i> Issues"
+    url = "https://github.com/carlosprados/keystone/issues"
+    weight = 30


### PR DESCRIPTION
Adds `site/`: a Hugo documentation site with the
[Relearn](https://mcshelby.github.io/hugo-theme-relearn/) theme, published to GitHub
Pages by CI.

## Why

The README has been carrying concepts, reference and rationale at once, and the
project has outgrown it. Reconcile semantics, the component state guarantees,
privilege dropping and three interchangeable control planes each need space to be
*explained* rather than listed — and some of them (why reuse requires a live
supervision loop, why the privilege drop happens in a shim) only make sense with the
reasoning attached.

## What is in it

Seven chapters, 22 pages, readable start to finish:

| Chapter | Covers |
|---|---|
| **Basics** | What Keystone is and is not, the four words (recipe / plan / component / agent), install, a first two-component deployment on your own machine |
| **Core concepts** | Recipes field by field, plans and the apply flow, dependency types and layers, the component state contract, reconcile and reuse |
| **How it works inside** | The three interfaces, the supervisor FSM, both runners, artifacts, state and crash recovery |
| **Security** | Secure defaults and fail-closed, signing and trust rotation, API authentication, process privileges |
| **Control planes** | HTTP endpoints, NATS subjects and JetStream, MQTT topics and last-will |
| **Operations** | Metrics with alert rules worth having, troubleshooting by symptom, a hardened systemd unit |
| **Reference** | Flags, environment variables, HTTP API, full recipe and plan schema |

Every page opens in plain language — several carry an explicit "like you're five"
callout — then goes into detail. Mermaid diagrams cover the flows that prose handles
badly: the apply path, layered parallel start, the supervisor state machine, the
privilege-drop shim, and orphan reaping on boot.

## Accuracy

The parts that would rot silently are taken from the code rather than retyped:

- the CLI reference embeds real `keystone --help` output;
- metric names come from `internal/metrics`, endpoints from the router, environment
  variables from a grep of `KEYSTONE_*`;
- the systemd page quotes `configs/systemd/keystone.service`;
- the state, reconcile and privilege pages document the guarantees as implemented in
  #12, #15 and #16, including the two known gaps (#13 container liveness, and
  `planPath` still accepted by NATS/MQTT).

Where something is *not* enforced — `memory_limit` and `cpu_quota` for process
components, filesystem confinement, release signing — the docs say so rather than
implying coverage.

## CI

`.github/workflows/pages.yml`:

- **push to `main`** touching `site/**` → build and deploy;
- **pull request** → build only, and fail on broken internal links;
- **manual dispatch** → publish out of band.

It deploys from `main` deliberately: the site describes released behaviour, and
publishing straight from `develop` would document flags a downloaded binary does not
have. The theme is a Hugo module, so the workflow installs Go and Hugo extended and
resolves it at build time — nothing vendored into the repo.

## Before it goes live

GitHub Pages must be set to **build from GitHub Actions** in the repository settings
(Settings → Pages → Source: GitHub Actions), and the site publishes on the first
push to `main` that includes `site/`.

## Verified

`hugo --gc --minify` builds clean — no errors, and the only remaining warnings come
from the theme's own templates against Hugo 0.164, not from this configuration. Every
page was checked over a local server (all 200), the sidebar renders all seven
chapters, and the mermaid diagrams are emitted as theme-rendered blocks.
