### PR TITLE
docs(site): correct the keystonectl and health-probe reference

### DIFF
--- a/site/content/basics/first-deployment.md
+++ b/site/content/basics/first-deployment.md
@@ -157,8 +157,10 @@ Everything above works through `keystonectl` too:
 
 ```bash
 keystonectl status
+keystonectl components
 keystonectl apply plan.toml
 keystonectl restart clock
+keystonectl stop-plan
 ```
 
 ## What to read next

--- a/site/content/concepts/recipes.md
+++ b/site/content/concepts/recipes.md
@@ -129,7 +129,7 @@ See [Containers](../../internals/runners/) for how the runtime is chosen.
 
 ```toml
 [lifecycle.run.health]
-check = "http://127.0.0.1:8080/healthz"   # http:// | tcp:// | cmd:…
+check = "http://127.0.0.1:8080/healthz"   # http:// | https:// | tcp:// | cmd:…
 interval = "10s"
 timeout = "2s"
 failure_threshold = 3

--- a/site/content/control-planes/http.md
+++ b/site/content/control-planes/http.md
@@ -57,13 +57,15 @@ The same API with less typing:
 
 ```bash
 keystonectl status
+keystonectl components
 keystonectl apply plan.toml
-keystonectl restart api --wait health
-keystonectl stop api
+keystonectl restart api
+keystonectl stop api          # one component
+keystonectl stop-plan         # everything
 ```
 
 It reads `KEYSTONE_API_TOKEN` from the environment and takes `--addr` for a remote
-agent.
+agent. See [the CLI reference](../../reference/cli/) for every subcommand.
 
 ## Bruno collection
 

--- a/site/content/internals/runners.md
+++ b/site/content/internals/runners.md
@@ -58,10 +58,14 @@ anything — so their liveness signal is the supervision loop. See the caveat in
 Three forms, all with `interval`, `timeout` and `failure_threshold`:
 
 ```toml
-check = "http://127.0.0.1:8080/healthz"   # 2xx/3xx is healthy
+check = "http://127.0.0.1:8080/healthz"   # 2xx is healthy — a redirect is not
+check = "https://127.0.0.1:8443/healthz"  # same, over TLS
 check = "tcp://127.0.0.1:5432"            # a successful connect is healthy
 check = "cmd:/usr/local/bin/check.sh"     # exit 0 is healthy
 ```
+
+The HTTP probe accepts **200–299 only**. A health endpoint that redirects reads as
+unhealthy, which catches a surprising number of misconfigured reverse proxies.
 
 Health interacts with the restart policy:
 

--- a/site/content/reference/cli.md
+++ b/site/content/reference/cli.md
@@ -98,16 +98,34 @@ Flags always win over the equivalent environment variable.
 ## keystonectl
 
 ```bash
-keystonectl status                     # plan status and components
-keystonectl apply plan.toml            # upload and apply a plan
-keystonectl stop                       # stop the whole plan
-keystonectl stop <component>           # stop one component
-keystonectl restart <component>        # restart one, cascading per dependency type
-keystonectl restart <component> --wait health --timeout 60s
+keystonectl version                       # client version and commit
+keystonectl status                        # plan status
+keystonectl components                    # every component with state, PID, health
+keystonectl graph                         # dependency graph and start order
+
+keystonectl apply plan.toml               # upload and apply a plan
+keystonectl apply plan.toml --dry         # same, previewing only
+keystonectl apply-dry plan.toml           # ditto
+keystonectl stop-plan                     # stop every component
+
+keystonectl stop <component>              # stop one component
+keystonectl restart <component>           # restart one, cascading per dependency type
+keystonectl restart-dry <component>       # what a restart would touch
+
+keystonectl recipes                       # list the recipe store
+keystonectl upload-recipe api.toml        # add a recipe (--force to overwrite)
+keystonectl sha256 dist/api.tar.gz        # compute a digest for a recipe artifact
 ```
 
-`--addr` points at a remote agent; the token comes from `--token` or
-`KEYSTONE_API_TOKEN`.
+Note `stop-plan` (everything) versus `stop <component>` (one thing) — they are
+different commands, and the plural mistake is an outage.
+
+Two global flags: `--addr` (default `http://127.0.0.1:8080`) for a remote agent, and
+`--token`, which falls back to `KEYSTONE_API_TOKEN`.
+
+The CLI is a thin wrapper over the HTTP API, so the wait-for-health behaviour of
+`POST /v1/components/{name}:restart?wait=health` is available with curl but not yet
+exposed as a `keystonectl` flag.
 
 ## keystoneserver
 

--- a/site/content/reference/schemas.md
+++ b/site/content/reference/schemas.md
@@ -101,7 +101,7 @@ That is the entire plan schema. Everything else is in the recipe.
 
 | Field | Type | Default | Notes |
 |---|---|---|---|
-| `check` | string | — | `http://…`, `tcp://…`, `cmd:…` |
+| `check` | string | — | `http://…` or `https://…` (2xx only), `tcp://…`, `cmd:…` |
 | `interval` | duration | `10s` | |
 | `timeout` | duration | `3s` | |
 | `failure_threshold` | int | `3` | |


### PR DESCRIPTION
Two documentation bugs in the site added by #17, both found by checking the pages against the code.

**`keystonectl` subcommands.** There is no `keystonectl stop` that stops the whole plan — that is `stop-plan`; `stop` takes a component name. Documenting the wrong one is an outage waiting to happen. The reference now lists what `cmd/keystonectl/main.go` actually dispatches (`version`, `status`, `components`, `graph`, `apply`, `apply-dry`, `stop-plan`, `stop`, `restart`, `restart-dry`, `recipes`, `upload-recipe`, `sha256`) and drops the invented `--wait`/`--timeout` flags — those parameters exist on `POST /v1/components/{name}:restart` but are not exposed by the CLI, which the page now says explicitly.

**Health probe semantics.** The HTTP probe accepts **200–299 only**, not 2xx/3xx as the page claimed, and `https://` is supported alongside `http://`. A health endpoint that redirects therefore reads as unhealthy — worth knowing before pointing one at a reverse proxy.

Corrected on four pages (reference/cli, reference/schemas, control-planes/http, basics/first-deployment, internals/runners). Site rebuilds clean.