### PR TITLE
docs(site): correct the API response shapes

### DIFF
--- a/site/content/concepts/plans.md
+++ b/site/content/concepts/plans.md
@@ -74,6 +74,9 @@ alive and supervised are left completely alone. See
 curl -s http://127.0.0.1:8080/v1/plan/status | jq
 ```
 
+The response carries `planPath`, `status`, the component list, and `error` when the
+last operation failed.
+
 | Status | Meaning |
 |---|---|
 | `idle` | No plan has been applied |

--- a/site/content/reference/api.md
+++ b/site/content/reference/api.md
@@ -47,8 +47,17 @@ anything not running. The guarantees these fields carry are in
 ## GET /v1/plan/status
 
 ```json
-{ "path": "plan.toml", "status": "running", "error": "" }
+{
+  "planPath": "plan.toml",
+  "status": "running",
+  "components": [
+    { "name": "api", "state": "running", "restarts": 0, "last_health": "healthy", "pid": 40219 }
+  ]
+}
 ```
+
+`error` is present only when the last operation failed. Note that this endpoint
+carries the component list too, so a fleet poller needs one request, not two.
 
 ## GET /v1/plan/graph
 
@@ -112,9 +121,22 @@ Stops one component. Its dependents are **not** stopped.
 | `dry` | `true` | Report what would be restarted, change nothing |
 
 ```json
-{ "name": "api", "restarted": ["api", "dashboard"], "pid": 41002, "waited": "1.2s" }
+{
+  "component": "api",
+  "pid": 41002,
+  "dependents": { "dashboard": 41055 },
+  "wait": "pid",
+  "timeout": "30s"
+}
 ```
 
-Dependents are restarted according to each edge's
+`dependents` maps each cascaded component to its new PID, so one call tells you
+everything that moved. Dependents are restarted according to each edge's
 [dependency type](../../concepts/dependencies/) — `hard` and `soft` cascade,
 `ordering` does not.
+
+With `dry=true` the shape is different — the plan, not the result:
+
+```json
+{ "stopOrder": ["dashboard", "api"], "startOrder": ["api", "dashboard"] }
+```


### PR DESCRIPTION
Third pass over the site added in #17, checking documented JSON against the structs `internal/adapter` actually encodes.

- **`GET /v1/plan/status`** returns `planPath`, not `path` — and it carries the full component list, which the page did not mention. That is useful: a fleet poller needs one request, not two.
- **The restart response** is `{component, pid, dependents{name: pid}, wait, timeout}`, not the `{name, restarted[], pid, waited}` the page invented. `dependents` maps each cascaded component to its **new PID**, so one call reports everything that moved.
- **The restart dry-run** has a different shape again — `{stopOrder[], startOrder[]}` — now documented separately.

Verified against `adapter.PlanStatus`, `adapter.RestartResult` and `adapter.RestartDryResult`. Site rebuilds clean.