### PR TITLE
docs(site): the extraction cap has a default (2 GiB), not none

### DIFF
--- a/site/content/internals/artifacts.md
+++ b/site/content/internals/artifacts.md
@@ -53,8 +53,8 @@ protections that matter when the archive comes off the network:
 
 - **Zip-slip containment** — entries that escape the target directory are refused.
 - **Mode stripping** — setuid, setgid and world-writable bits are removed.
-- **Size cap** — `KEYSTONE_MAX_EXTRACT_BYTES` bounds the decompressed size, so a
-  small archive cannot fill the disk.
+- **Size cap** — `KEYSTONE_MAX_EXTRACT_BYTES` (2 GiB by default) bounds the
+  decompressed size, so a small archive cannot fill the disk.
 
 ## The cache
 

--- a/site/content/reference/env.md
+++ b/site/content/reference/env.md
@@ -20,7 +20,7 @@ anything else, so these can live there or in a systemd `EnvironmentFile`.
 | `KEYSTONE_LEAF_CERT` | — | Provisioned signing leaf certificate |
 | `KEYSTONE_INSECURE_SKIP_VERIFY` | `false` | Disables mandatory artifact integrity. Development only |
 | `KEYSTONE_MAX_REQUEST_BYTES` | 4 MiB | HTTP request body cap (413 on overflow) |
-| `KEYSTONE_MAX_EXTRACT_BYTES` | — | Cap on decompressed archive size |
+| `KEYSTONE_MAX_EXTRACT_BYTES` | 2 GiB | Cap on decompressed archive size, so a small archive cannot fill the disk |
 
 ## Artifacts
 


### PR DESCRIPTION
`KEYSTONE_MAX_EXTRACT_BYTES` was documented with no default, which reads as "unbounded until you set it" — the opposite of the truth. It defaults to **2 GiB** (`defaultMaxExtractBytes` in `internal/artifact/manager.go`).

Corrected on the environment reference and the artifacts page.