### PR TITLE
docs: correct the reference pages against the code

### DIFF
--- a/site/content/basics/first-deployment.md
+++ b/site/content/basics/first-deployment.md
@@ -157,8 +157,10 @@ Everything above works through `keystonectl` too:
 
 ```bash
 keystonectl status
+keystonectl components
 keystonectl apply plan.toml
 keystonectl restart clock
+keystonectl stop-plan
 ```
 
 ## What to read next

--- a/site/content/concepts/plans.md
+++ b/site/content/concepts/plans.md
@@ -74,6 +74,9 @@ alive and supervised are left completely alone. See
 curl -s http://127.0.0.1:8080/v1/plan/status | jq
 ```
 
+The response carries `planPath`, `status`, the component list, and `error` when the
+last operation failed.
+
 | Status | Meaning |
 |---|---|
 | `idle` | No plan has been applied |

--- a/site/content/concepts/recipes.md
+++ b/site/content/concepts/recipes.md
@@ -129,7 +129,7 @@ See [Containers](../../internals/runners/) for how the runtime is chosen.
 
 ```toml
 [lifecycle.run.health]
-check = "http://127.0.0.1:8080/healthz"   # http:// | tcp:// | cmd:…
+check = "http://127.0.0.1:8080/healthz"   # http:// | https:// | tcp:// | cmd:…
 interval = "10s"
 timeout = "2s"
 failure_threshold = 3

--- a/site/content/control-planes/http.md
+++ b/site/content/control-planes/http.md
@@ -57,13 +57,15 @@ The same API with less typing:
 
 ```bash
 keystonectl status
+keystonectl components
 keystonectl apply plan.toml
-keystonectl restart api --wait health
-keystonectl stop api
+keystonectl restart api
+keystonectl stop api          # one component
+keystonectl stop-plan         # everything
 ```
 
 It reads `KEYSTONE_API_TOKEN` from the environment and takes `--addr` for a remote
-agent.
+agent. See [the CLI reference](../../reference/cli/) for every subcommand.
 
 ## Bruno collection
 

--- a/site/content/internals/artifacts.md
+++ b/site/content/internals/artifacts.md
@@ -53,8 +53,8 @@ protections that matter when the archive comes off the network:
 
 - **Zip-slip containment** — entries that escape the target directory are refused.
 - **Mode stripping** — setuid, setgid and world-writable bits are removed.
-- **Size cap** — `KEYSTONE_MAX_EXTRACT_BYTES` bounds the decompressed size, so a
-  small archive cannot fill the disk.
+- **Size cap** — `KEYSTONE_MAX_EXTRACT_BYTES` (2 GiB by default) bounds the
+  decompressed size, so a small archive cannot fill the disk.
 
 ## The cache
 

--- a/site/content/internals/runners.md
+++ b/site/content/internals/runners.md
@@ -58,10 +58,14 @@ anything — so their liveness signal is the supervision loop. See the caveat in
 Three forms, all with `interval`, `timeout` and `failure_threshold`:
 
 ```toml
-check = "http://127.0.0.1:8080/healthz"   # 2xx/3xx is healthy
+check = "http://127.0.0.1:8080/healthz"   # 2xx is healthy — a redirect is not
+check = "https://127.0.0.1:8443/healthz"  # same, over TLS
 check = "tcp://127.0.0.1:5432"            # a successful connect is healthy
 check = "cmd:/usr/local/bin/check.sh"     # exit 0 is healthy
 ```
+
+The HTTP probe accepts **200–299 only**. A health endpoint that redirects reads as
+unhealthy, which catches a surprising number of misconfigured reverse proxies.
 
 Health interacts with the restart policy:
 

--- a/site/content/reference/api.md
+++ b/site/content/reference/api.md
@@ -47,8 +47,17 @@ anything not running. The guarantees these fields carry are in
 ## GET /v1/plan/status
 
 ```json
-{ "path": "plan.toml", "status": "running", "error": "" }
+{
+  "planPath": "plan.toml",
+  "status": "running",
+  "components": [
+    { "name": "api", "state": "running", "restarts": 0, "last_health": "healthy", "pid": 40219 }
+  ]
+}
 ```
+
+`error` is present only when the last operation failed. Note that this endpoint
+carries the component list too, so a fleet poller needs one request, not two.
 
 ## GET /v1/plan/graph
 
@@ -112,9 +121,22 @@ Stops one component. Its dependents are **not** stopped.
 | `dry` | `true` | Report what would be restarted, change nothing |
 
 ```json
-{ "name": "api", "restarted": ["api", "dashboard"], "pid": 41002, "waited": "1.2s" }
+{
+  "component": "api",
+  "pid": 41002,
+  "dependents": { "dashboard": 41055 },
+  "wait": "pid",
+  "timeout": "30s"
+}
 ```
 
-Dependents are restarted according to each edge's
+`dependents` maps each cascaded component to its new PID, so one call tells you
+everything that moved. Dependents are restarted according to each edge's
 [dependency type](../../concepts/dependencies/) — `hard` and `soft` cascade,
 `ordering` does not.
+
+With `dry=true` the shape is different — the plan, not the result:
+
+```json
+{ "stopOrder": ["dashboard", "api"], "startOrder": ["api", "dashboard"] }
+```

--- a/site/content/reference/cli.md
+++ b/site/content/reference/cli.md
@@ -98,16 +98,34 @@ Flags always win over the equivalent environment variable.
 ## keystonectl
 
 ```bash
-keystonectl status                     # plan status and components
-keystonectl apply plan.toml            # upload and apply a plan
-keystonectl stop                       # stop the whole plan
-keystonectl stop <component>           # stop one component
-keystonectl restart <component>        # restart one, cascading per dependency type
-keystonectl restart <component> --wait health --timeout 60s
+keystonectl version                       # client version and commit
+keystonectl status                        # plan status
+keystonectl components                    # every component with state, PID, health
+keystonectl graph                         # dependency graph and start order
+
+keystonectl apply plan.toml               # upload and apply a plan
+keystonectl apply plan.toml --dry         # same, previewing only
+keystonectl apply-dry plan.toml           # ditto
+keystonectl stop-plan                     # stop every component
+
+keystonectl stop <component>              # stop one component
+keystonectl restart <component>           # restart one, cascading per dependency type
+keystonectl restart-dry <component>       # what a restart would touch
+
+keystonectl recipes                       # list the recipe store
+keystonectl upload-recipe api.toml        # add a recipe (--force to overwrite)
+keystonectl sha256 dist/api.tar.gz        # compute a digest for a recipe artifact
 ```
 
-`--addr` points at a remote agent; the token comes from `--token` or
-`KEYSTONE_API_TOKEN`.
+Note `stop-plan` (everything) versus `stop <component>` (one thing) — they are
+different commands, and the plural mistake is an outage.
+
+Two global flags: `--addr` (default `http://127.0.0.1:8080`) for a remote agent, and
+`--token`, which falls back to `KEYSTONE_API_TOKEN`.
+
+The CLI is a thin wrapper over the HTTP API, so the wait-for-health behaviour of
+`POST /v1/components/{name}:restart?wait=health` is available with curl but not yet
+exposed as a `keystonectl` flag.
 
 ## keystoneserver
 

--- a/site/content/reference/env.md
+++ b/site/content/reference/env.md
@@ -20,7 +20,7 @@ anything else, so these can live there or in a systemd `EnvironmentFile`.
 | `KEYSTONE_LEAF_CERT` | — | Provisioned signing leaf certificate |
 | `KEYSTONE_INSECURE_SKIP_VERIFY` | `false` | Disables mandatory artifact integrity. Development only |
 | `KEYSTONE_MAX_REQUEST_BYTES` | 4 MiB | HTTP request body cap (413 on overflow) |
-| `KEYSTONE_MAX_EXTRACT_BYTES` | — | Cap on decompressed archive size |
+| `KEYSTONE_MAX_EXTRACT_BYTES` | 2 GiB | Cap on decompressed archive size, so a small archive cannot fill the disk |
 
 ## Artifacts
 

--- a/site/content/reference/schemas.md
+++ b/site/content/reference/schemas.md
@@ -101,7 +101,7 @@ That is the entire plan schema. Everything else is in the recipe.
 
 | Field | Type | Default | Notes |
 |---|---|---|---|
-| `check` | string | — | `http://…`, `tcp://…`, `cmd:…` |
+| `check` | string | — | `http://…` or `https://…` (2xx only), `tcp://…`, `cmd:…` |
 | `interval` | duration | `10s` | |
 | `timeout` | duration | `3s` | |
 | `failure_threshold` | int | `3` | |


### PR DESCRIPTION
Three corrections to the site added in #17, each found by checking a page against the code rather than trusting it:

- **#19** — `keystonectl` has no `stop` for the whole plan (that is `stop-plan`; `stop` takes a component name), and the `--wait`/`--timeout` flags I documented exist on the HTTP endpoint, not on the CLI. Also: the HTTP health probe accepts **200–299 only**, not 2xx/3xx, and `https://` is supported.
- **#20** — `GET /v1/plan/status` returns `planPath`, not `path`, and carries the component list; the restart response is `{component, pid, dependents{name: pid}, wait, timeout}`, not what the page invented; the restart dry-run has its own shape.
- **#21** — `KEYSTONE_MAX_EXTRACT_BYTES` defaults to 2 GiB; documenting it as having no default read as "unbounded until you set it".

Promoting so the published site carries them. `main` is what the docs workflow deploys from.