### PR TITLE
ci: build the site on GitHub, run the checks here

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,6 +2,11 @@ name: docs
 
 # Builds the documentation site in site/ and publishes it to GitHub Pages.
 #
+# This workflow only runs Hugo. Content checks — layout, broken links, diagram
+# legibility — are local tools, run with `task docs:check` and
+# `task docs:check:diagrams` before pushing. Relearn renders mermaid in the
+# browser, so nothing here needs one.
+#
 # Deploys from main only: the site documents features as released, and publishing
 # from develop would describe flags that a downloaded binary does not have yet.
 #
@@ -13,7 +18,8 @@ name: docs
 #                       rebuild (a change to a Go response type regenerates the
 #                       OpenAPI document, which lives under site/).
 #   - tag v*            cutting a release republishes the docs for that release.
-#   - pull request      builds without deploying, and fails on a broken link.
+#   - pull request      builds without deploying, so a broken site is caught
+#                       before it is merged.
 #   - manual dispatch   publish out of band.
 on:
   push:
@@ -85,47 +91,6 @@ jobs:
           # prove the site builds.
           hugo --gc --minify \
             ${{ steps.pages.outputs.base_url && format('--baseURL {0}', steps.pages.outputs.base_url) || '' }}
-
-      - name: Fail on broken internal links
-        working-directory: site
-        run: |
-          # Hugo resolves relative links at build time, so a typo becomes a link to
-          # a page that does not exist. Catch the obvious ones.
-          missing=0
-          while read -r target; do
-            [ -f "public/${target}index.html" ] || [ -f "public/${target%/}.html" ] || {
-              echo "::error::broken internal link target: ${target}"
-              missing=1
-            }
-          done < <(grep -rhoE 'href="/keystone/[a-z0-9/-]*/"' public --include='*.html' \
-                    | sed -E 's|href="/keystone/||; s|"$||' | sort -u)
-          exit $missing
-
-      - name: Layout is sound
-        # Catches what the Hugo build cannot: a duplicated page title, a sidebar
-        # footer that did not render (or rendered on top of the menu), a chapter
-        # missing from the navigation, an unrendered shortcode. All of these
-        # compile perfectly and only show up to a reader.
-        run: python3 site/scripts/check-layout.py
-
-      # Only on pull requests. This one drives a headless Chromium, so it is the
-      # slowest thing here by far; keeping it off the publish path means a merge or
-      # a release tag goes live in about a minute instead of waiting on a browser.
-      # A diagram cannot reach main without passing it, which is the point.
-      - name: Cache the mermaid renderer
-        if: github.event_name == 'pull_request'
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.npm
-            ~/.cache/puppeteer
-          key: mermaid-cli-${{ runner.os }}-v1
-
-      - name: Diagrams render legibly
-        if: github.event_name == 'pull_request'
-        # Renders every diagram in one browser launch and fails if any would show
-        # text below the legible threshold once scaled into the content column.
-        run: python3 site/scripts/check-diagrams.py
 
       - uses: actions/upload-pages-artifact@v3
         if: github.event_name != 'pull_request'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -108,10 +108,23 @@ jobs:
         # compile perfectly and only show up to a reader.
         run: python3 site/scripts/check-layout.py
 
+      # Only on pull requests. This one drives a headless Chromium, so it is the
+      # slowest thing here by far; keeping it off the publish path means a merge or
+      # a release tag goes live in about a minute instead of waiting on a browser.
+      # A diagram cannot reach main without passing it, which is the point.
+      - name: Cache the mermaid renderer
+        if: github.event_name == 'pull_request'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.npm
+            ~/.cache/puppeteer
+          key: mermaid-cli-${{ runner.os }}-v1
+
       - name: Diagrams render legibly
-        # A diagram wider than the content column is scaled down by the browser and
-        # its text shrinks with it. This renders each one and fails if the effective
-        # font size would be too small to read.
+        if: github.event_name == 'pull_request'
+        # Renders every diagram in one browser launch and fails if any would show
+        # text below the legible threshold once scaled into the content column.
         run: python3 site/scripts/check-diagrams.py
 
       - uses: actions/upload-pages-artifact@v3

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -92,10 +92,14 @@ tasks:
       - hugo server
 
   docs:check:
-    desc: Build the docs and run the layout and diagram checks
+    desc: Build the docs and run the fast layout checks
     cmds:
       - cd site && hugo --gc --minify
       - python3 site/scripts/check-layout.py
+
+  docs:check:diagrams:
+    desc: Check diagram legibility (drives a headless Chromium, ~40s)
+    cmds:
       - python3 site/scripts/check-diagrams.py
 
   test:

--- a/site/README.md
+++ b/site/README.md
@@ -24,22 +24,21 @@ Pushes to `main` build and deploy, as do release tags. Pull requests build witho
 deploying. The workflow can also be run manually (**Actions → docs → Run workflow**)
 to publish out of band.
 
-Three checks guard the site, and they are deliberately not all on the same path:
+Checks are **local**, not CI. The workflow only runs Hugo — Relearn renders mermaid in
+the browser, so nothing on the server side needs one.
 
-| Check | Runs on | Why there |
-|---|---|---|
-| Broken internal links | every run | Milliseconds, pure shell |
-| `check-layout.py` | every run | Milliseconds, pure Python. Catches duplicated titles, a sidebar footer that did not render, a chapter missing from the navigation |
-| `check-diagrams.py` | **pull requests only** | Drives a headless Chromium, so it is the slow one. A diagram cannot reach `main` without passing it, but a merge or a release tag publishes without waiting on a browser |
+```bash
+task docs:check              # build, then layout + broken internal links (milliseconds)
+task docs:check:diagrams     # diagram legibility (headless Chromium, ~40s)
+```
 
-`check-diagrams.py` renders every diagram in a single mermaid-cli invocation — one
-browser launch for the whole site, about 40 seconds, rather than one launch per
-diagram, which took a quarter of an hour. If the batch fails it falls back to
-rendering one at a time so the offending page can be named.
+| Check | What it catches |
+|---|---|
+| `check-layout.py` | Duplicated page titles, a sidebar footer that did not render or landed over the menu, a chapter missing from the navigation, unrendered shortcodes, `ZgotmplZ`, broken internal links (absolute **and** relative — Hugo passes relative markdown links through untouched, which is the shape a typo takes) |
+| `check-diagrams.py` | A diagram wider than the content column, whose text the browser shrinks below legibility. Renders all of them in one mermaid-cli launch (~40s for the whole site) |
 
-It deploys from `main` on purpose: the site describes released behaviour, so
-publishing straight from `develop` would document flags that a downloaded binary
-does not have yet.
+Run both before pushing anything under `site/`. The trade-off is explicit: nothing stops
+a bad diagram or a duplicated title reaching `main` except running these.
 
 ## Updating the theme
 

--- a/site/README.md
+++ b/site/README.md
@@ -20,9 +20,22 @@ each page's `weight`, and chapter landing pages list their children with the
 
 ## Publishing
 
-Pushes to `main` that touch `site/**` build and deploy. Pull requests build without
-deploying, and fail on a broken internal link. The workflow can also be run
-manually (**Actions → docs → Run workflow**) to publish out of band.
+Pushes to `main` build and deploy, as do release tags. Pull requests build without
+deploying. The workflow can also be run manually (**Actions → docs → Run workflow**)
+to publish out of band.
+
+Three checks guard the site, and they are deliberately not all on the same path:
+
+| Check | Runs on | Why there |
+|---|---|---|
+| Broken internal links | every run | Milliseconds, pure shell |
+| `check-layout.py` | every run | Milliseconds, pure Python. Catches duplicated titles, a sidebar footer that did not render, a chapter missing from the navigation |
+| `check-diagrams.py` | **pull requests only** | Drives a headless Chromium, so it is the slow one. A diagram cannot reach `main` without passing it, but a merge or a release tag publishes without waiting on a browser |
+
+`check-diagrams.py` renders every diagram in a single mermaid-cli invocation — one
+browser launch for the whole site, about 40 seconds, rather than one launch per
+diagram, which took a quarter of an hour. If the batch fails it falls back to
+rendering one at a time so the offending page can be named.
 
 It deploys from `main` on purpose: the site describes released behaviour, so
 publishing straight from `develop` would document flags that a downloaded binary

--- a/site/scripts/check-diagrams.py
+++ b/site/scripts/check-diagrams.py
@@ -3,29 +3,36 @@
 
 A diagram wider than the content column is scaled down by the browser and its text
 shrinks with it, which is how a perfectly valid diagram ends up unreadable. This
-renders each one with mermaid-cli and reports the *effective* font size — the native
-size multiplied by the scale factor the column would impose.
+renders each one and reports the *effective* font size: the native size multiplied
+by the scale factor the column would impose.
+
+Every diagram on the site is rendered in a single mermaid-cli invocation, which
+launches one browser instead of one per diagram — the difference between about a
+minute and a quarter of an hour on CI. If that batch fails, the script falls back to
+rendering diagrams one at a time so the broken one can be named.
 
 Usage:
     python3 site/scripts/check-diagrams.py [--budget 720] [--min 13.5]
 
-Requires npx (mermaid-cli is fetched on demand). Chrome needs --no-sandbox on hosts
-with unprivileged user namespaces disabled, which the generated puppeteer config
-handles.
+Requires npx; mermaid-cli is fetched on demand. Chrome needs --no-sandbox on hosts
+where unprivileged user namespaces are restricted, which the generated puppeteer
+config handles.
 """
-import argparse, json, pathlib, re, subprocess, sys, tempfile
+import argparse
+import json
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
 
-def render(mmd: pathlib.Path, out: pathlib.Path, pptr: pathlib.Path, cfg: pathlib.Path) -> bool:
-    r = subprocess.run(
-        ["npx", "-y", "@mermaid-js/mermaid-cli", "-p", str(pptr), "-c", str(cfg),
-         "-i", str(mmd), "-o", str(out)],
-        capture_output=True, text=True, timeout=300)
-    if not out.exists():
-        print(f"  render failed: {r.stderr.strip()[-300:]}", file=sys.stderr)
-        return False
-    return True
 
-def visible_font_sizes(svg: str):
+def mmdc(args: list[str], timeout: int) -> subprocess.CompletedProcess:
+    return subprocess.run(["npx", "-y", "@mermaid-js/mermaid-cli", *args],
+                          capture_output=True, text=True, timeout=timeout)
+
+
+def visible_font_sizes(svg: str) -> list[float]:
     """Font sizes of text the reader actually sees, ignoring the hidden tooltip."""
     sizes = []
     for m in re.finditer(r'<(?:text|tspan|span|p|div)[^>]*font-size:\s*([\d.]+)px', svg):
@@ -39,6 +46,33 @@ def visible_font_sizes(svg: str):
             sizes.append(float(m.group(3)))
     return sizes
 
+
+def measure(svg_text: str, budget: float) -> tuple[float, float]:
+    """Return (intrinsic width, effective font size in the content column)."""
+    vb = re.search(r'<svg[^>]*viewBox="[-\d.]+ [-\d.]+ ([\d.]+) ([\d.]+)"', svg_text)
+    width = float(vb.group(1)) if vb else 0.0
+    fonts = visible_font_sizes(svg_text)
+    native = min(fonts) if fonts else 0.0
+    effective = native * min(1.0, budget / width) if width else 0.0
+    return width, effective
+
+
+def collect(content: pathlib.Path) -> list[tuple[pathlib.Path, int, str]]:
+    found = []
+    for page in sorted(content.rglob('*.md')):
+        for i, block in enumerate(re.finditer(r'```mermaid\n(.*?)```', page.read_text(), re.S)):
+            found.append((page, i, block.group(1)))
+    return found
+
+
+def theme_config(config_path: pathlib.Path) -> str:
+    """The site's own mermaid config, so the check sees what readers see."""
+    if not config_path.is_file():
+        return '{}'
+    m = re.search(r'mermaidInitialize\s*=\s*"(.*)"\s*$', config_path.read_text(), re.M)
+    return json.loads('"' + m.group(1) + '"') if m else '{}'
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument('--budget', type=float, default=720,
@@ -49,51 +83,67 @@ def main() -> int:
     ap.add_argument('--config', default='site/hugo.toml')
     args = ap.parse_args()
 
-    # Reuse the site's own mermaid config, so the check sees what readers see.
-    theme_css = ''
-    cfg_text = pathlib.Path(args.config).read_text()
-    m = re.search(r'mermaidInitialize\s*=\s*"(.*)"\s*$', cfg_text, re.M)
-    if m:
-        theme_css = json.loads('"' + m.group(1) + '"')
+    diagrams = collect(pathlib.Path(args.content))
+    if not diagrams:
+        print(f"::error::no mermaid diagrams found under {args.content}")
+        return 1
 
-    with tempfile.TemporaryDirectory() as tmp:
-        tmp = pathlib.Path(tmp)
-        pptr = tmp/'pptr.json'
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = pathlib.Path(tmpdir)
+        pptr = tmp / 'pptr.json'
         pptr.write_text(json.dumps({"args": ["--no-sandbox", "--disable-dev-shm-usage"]}))
-        cfg = tmp/'mermaid.json'
-        cfg.write_text(theme_css or '{}')
+        cfg = tmp / 'mermaid.json'
+        cfg.write_text(theme_config(pathlib.Path(args.config)))
 
-        failures = []
-        checked = 0
-        for page in sorted(pathlib.Path(args.content).rglob('*.md')):
-            for i, block in enumerate(re.finditer(r'```mermaid\n(.*?)```', page.read_text(), re.S)):
-                checked += 1
-                name = f"{page.stem}-{i}"
-                mmd = tmp/f"{name}.mmd"; mmd.write_text(block.group(1))
-                svg = tmp/f"{name}.svg"
-                if not render(mmd, svg, pptr, cfg):
-                    failures.append((page, i, 'failed to render'))
-                    continue
-                t = svg.read_text()
-                vb = re.search(r'<svg[^>]*viewBox="[-\d.]+ [-\d.]+ ([\d.]+) ([\d.]+)"', t)
-                width = float(vb.group(1)) if vb else 0
-                fonts = visible_font_sizes(t)
-                native = min(fonts) if fonts else 0
-                effective = native * min(1.0, args.budget/width) if width else 0
-                if effective < args.min_font:
-                    failures.append((page, i, f"{width:.0f}px wide, text renders at "
-                                              f"{effective:.1f}px (min {args.min_font}px)"))
+        # One markdown file with every diagram, in order. mermaid-cli writes
+        # out-1.svg, out-2.svg, … following that order.
+        batch = tmp / 'all.md'
+        batch.write_text('\n\n'.join(f"```mermaid\n{src}```" for _, _, src in diagrams))
+        result = mmdc(['-p', str(pptr), '-c', str(cfg), '-i', str(batch),
+                       '-o', str(tmp / 'out.md')], timeout=900)
 
-        print(f"checked {checked} diagrams")
-        for page, i, why in failures:
-            print(f"::error file={page}::diagram {i}: {why}")
-        if failures:
-            print(f"\n{len(failures)} diagram(s) would be hard to read. Make them "
-                  f"narrower: switch a wide fan-out to `flowchart LR` so branches "
-                  f"stack, split it in two, or shorten the labels.")
-            return 1
-        print("all diagrams render legibly")
-        return 0
+        svgs: list[pathlib.Path | None] = []
+        for n in range(1, len(diagrams) + 1):
+            candidate = tmp / f'out-{n}.svg'
+            svgs.append(candidate if candidate.exists() else None)
+
+        if any(s is None for s in svgs):
+            # Something in the batch failed. Render individually so the error can
+            # be attributed to a page instead of reported for the whole site.
+            print(f"batch render incomplete ({sum(s is None for s in svgs)} missing), "
+                  f"falling back to one diagram at a time", file=sys.stderr)
+            if result.stderr.strip():
+                print(result.stderr.strip()[-400:], file=sys.stderr)
+            svgs = []
+            for idx, (_, _, src) in enumerate(diagrams, start=1):
+                one = tmp / f'single-{idx}.mmd'
+                one.write_text(src)
+                out = tmp / f'single-{idx}.svg'
+                mmdc(['-p', str(pptr), '-c', str(cfg), '-i', str(one), '-o', str(out)],
+                     timeout=300)
+                svgs.append(out if out.exists() else None)
+
+        failures = 0
+        for (page, i, _), svg in zip(diagrams, svgs):
+            if svg is None:
+                print(f"::error file={page}::diagram {i}: failed to render")
+                failures += 1
+                continue
+            width, effective = measure(svg.read_text(), args.budget)
+            if effective < args.min_font:
+                print(f"::error file={page}::diagram {i}: {width:.0f}px wide, text renders "
+                      f"at {effective:.1f}px (minimum {args.min_font}px)")
+                failures += 1
+
+    print(f"checked {len(diagrams)} diagrams")
+    if failures:
+        print(f"\n{failures} diagram(s) would be hard to read. Make them narrower: "
+              f"switch a wide fan-out to `flowchart LR` so branches stack, split it "
+              f"in two, or shorten the labels.")
+        return 1
+    print("all diagrams render legibly")
+    return 0
+
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/site/scripts/check-layout.py
+++ b/site/scripts/check-layout.py
@@ -117,9 +117,76 @@ def check_page(path: pathlib.Path, html: str) -> list[str]:
     return problems
 
 
+def base_path(config_path: pathlib.Path) -> str:
+    """The path component of baseURL, which prefixes every internal link."""
+    if not config_path.is_file():
+        return ""
+    m = re.search(r'^baseURL\s*=\s*"([^"]+)"', config_path.read_text(), re.M)
+    if not m:
+        return ""
+    path = re.sub(r"^https?://[^/]+", "", m.group(1))
+    return "/" + path.strip("/") if path.strip("/") else ""
+
+
+# Assets, not pages: a link to one of these is fine and is not a page target.
+ASSET_SUFFIXES = (".css", ".js", ".png", ".svg", ".jpg", ".jpeg", ".gif", ".ico",
+                  ".woff", ".woff2", ".ttf", ".yaml", ".yml", ".json", ".xml",
+                  ".txt", ".zip", ".tar.gz", ".pdf", ".webmanifest")
+
+HREF = re.compile(r"""href=(?:"([^"]+)"|'([^']+)'|([^\s">]+))""")
+
+
+def check_links(root: pathlib.Path, prefix: str) -> list[str]:
+    """Internal links pointing at a page that was not built.
+
+    Hugo resolves relative links at build time without complaining, so a typo
+    becomes a link to a page that does not exist. Minified output drops the quotes
+    around attributes and writes targets as /prefix/path/index.html, which is why
+    this parses all three quoting forms and both path shapes.
+    """
+    targets: dict[str, str] = {}
+    for page in root.rglob("*.html"):
+        text = page.read_text(encoding="utf-8", errors="replace")
+        for m in HREF.finditer(text):
+            href = m.group(1) or m.group(2) or m.group(3) or ""
+            href = href.split("#")[0].split("?")[0]
+            if not href or "://" in href or href.startswith(("mailto:", "tel:", "data:")):
+                continue
+            if href.lower().endswith(ASSET_SUFFIXES):
+                continue
+            if href.startswith("/"):
+                targets.setdefault(href, str(page.relative_to(root)))
+            else:
+                # Hugo passes relative markdown links through untouched, which is
+                # exactly the shape a typo takes. Resolve against the page's own
+                # directory, the way a browser would.
+                resolved = (page.parent / href).resolve()
+                try:
+                    rel = resolved.relative_to(root.resolve())
+                except ValueError:
+                    continue          # escapes the site root; not ours to police
+                targets.setdefault("/" + str(rel), f"{page.relative_to(root)} (relative)")
+
+    problems = []
+    for target, seen_in in sorted(targets.items()):
+        rel = target
+        if prefix and rel.startswith(prefix + "/"):
+            rel = rel[len(prefix):]
+        rel = rel.strip("/")
+        if not rel:
+            rel = "index.html"
+        candidates = [root / rel, root / rel / "index.html", root / f"{rel}.html"]
+        if any(c.is_file() for c in candidates):
+            continue
+        problems.append(f"broken internal link {target} (linked from {seen_in})")
+    return problems
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--public", default="site/public")
+    ap.add_argument("--config", default="site/hugo.toml",
+                    help="used to learn the baseURL path that prefixes internal links")
     args = ap.parse_args()
 
     root = pathlib.Path(args.public)
@@ -135,6 +202,10 @@ def main() -> int:
         return 1
 
     failures = 0
+    for problem in check_links(root, base_path(pathlib.Path(args.config))):
+        print(f"::error::{problem}")
+        failures += 1
+
     for page in pages:
         problems = check_page(page, page.read_text(encoding="utf-8", errors="replace"))
         rel = page.relative_to(root)


### PR DESCRIPTION
**Decision applied: GitHub only runs Hugo. The checks run locally.** Relearn renders mermaid
in the browser, so nothing on the server side needs a headless one.

## The workflow now

```
checkout → setup-go (the theme is a Hugo module) → install Hugo → build → upload → deploy
```

That is it. No link check, no layout check, no browser. A merge or a release tag publishes in
about a minute.

## The checks, as local tools

```bash
task docs:check              # build, then layout + broken internal links (milliseconds)
task docs:check:diagrams     # diagram legibility (headless Chromium, ~40s for the site)
```

| Check | What it catches |
|---|---|
| `check-layout.py` | Duplicated page titles, a sidebar footer that did not render or landed over the menu, a chapter missing from the navigation, unrendered shortcodes, `ZgotmplZ`, and broken internal links |
| `check-diagrams.py` | A diagram wider than the content column, whose text the browser then shrinks below legibility |

The trade-off is explicit and documented in `site/README.md`: nothing stops a bad diagram or a
duplicated title reaching `main` except running these before pushing.

## Two things I had to fix while moving them

**The diagram check was launching a browser per diagram** — 37 launches, ~13 minutes.
mermaid-cli takes a whole markdown file and renders every diagram in it from one launch:
**39 seconds** for the site, measured. It falls back to per-diagram rendering if the batch
comes back incomplete, so a broken diagram is still attributed to its page.

**The link check did not work.** Moving it out of the workflow YAML exposed it: it only
matched quoted absolute hrefs ending in `/`. The minified output writes unquoted
`/keystone/path/index.html`, and Hugo passes **relative** markdown links through untouched —
which is exactly the shape a typo takes. So it matched nothing and reported success on a site
with a broken link in it. Now it parses all three quoting forms, both path shapes, strips the
baseURL prefix, and resolves relative hrefs against the page's own directory the way a browser
would.

## Verified by breaking things on purpose

- Mistyped a relative link → `broken internal link /operations/systemd-typo (linked from
  basics/install/index.html (relative))`. The old version said "layout is sound".
- Added a second H1 to a page → reported with both headings and the page name.
- Re-introduced the wide fan-out that measured 7.3px effective → still caught after the
  batching speedup.
- Clean tree → 45 pages, 37 diagrams, no false positives.

## On the minutes, for the record

This repository is **public**, so GitHub-hosted runner minutes are free and unmetered — the
2,000/month quota is for private repositories. There was no billing risk. What was real was
the wall-clock cost and the fragility of putting a 150 MB browser download on the critical
path to publishing.