### PR TITLE
fix(ci): stamp the last cut release and let a tag republish the docs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,15 +12,34 @@ name: docs
 #
 # Triggers, and why:
 #   - push to main      every merge, so the published docs never lag the branch
-#                       they describe. The build is ~40s and deploying an
-#                       unchanged site is a no-op, which is cheaper than
+#                       they describe. The build is ~40s, which is cheaper than
 #                       maintaining a path filter that silently skips a needed
 #                       rebuild (a change to a Go response type regenerates the
 #                       OpenAPI document, which lives under site/).
-#   - tag v*            cutting a release republishes the docs for that release.
+#   - tag v*            cutting a release republishes the docs for that release,
+#                       so the footer names the tag that was just cut. This needs
+#                       two things that are not obvious; see "Republishing" below.
 #   - pull request      builds without deploying, so a broken site is caught
 #                       before it is merged.
-#   - manual dispatch   publish out of band.
+#   - manual dispatch   publish out of band, and to re-serve a bad deployment.
+#
+# Republishing the same commit — two traps, both hit while cutting v0.3.0:
+#
+#   1. The github-pages environment must allow tag refs, or the deploy job is
+#      rejected in about a second with zero steps executed, which is
+#      indistinguishable from an Actions outage. Fixed on the environment:
+#        gh api -X POST \
+#          repos/carlosprados/keystone/environments/github-pages/deployment-branch-policies \
+#          -f name='v*' -f type=tag
+#
+#   2. Pages keys a deployment by pages_build_version, and actions/deploy-pages
+#      sends GITHUB_SHA for it. A release tag points at a commit main has already
+#      published, so the tag build reported success four times and was never
+#      served: the first deployment of a version wins and later ones for the same
+#      version are discarded. The deploy step below overrides GITHUB_SHA with a
+#      per-run value so every deployment is a new version. Consequence: a deploy
+#      is never a no-op now, and the commit shown for a Pages deployment is that
+#      composite string rather than a bare SHA.
 on:
   push:
     branches: [main]
@@ -72,14 +91,16 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: actions/configure-pages@v5
 
+      # The footer must name the last release that was cut, not the commit being
+      # built: `git describe --tags` alone appends a distance and a hash as soon
+      # as anything lands after the tag (main showed v0.2.1-33-ga1bcf26 while
+      # v0.3.0 was the current release), and on a tag build it only reports the
+      # tag because the tag happens to point at HEAD. --abbrev=0 reports the
+      # nearest reachable tag on both, so one code path covers branch and tag.
       - name: Work out the version being documented
         id: ver
         run: |
-          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
-            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
-          else
-            echo "version=$(git describe --tags --always)" >> "$GITHUB_OUTPUT"
-          fi
+          echo "version=$(git describe --tags --abbrev=0 2>/dev/null || echo dev)" >> "$GITHUB_OUTPUT"
 
       - name: Build
         working-directory: site
@@ -105,5 +126,10 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      # GITHUB_SHA is what deploy-pages sends as pages_build_version. Making it
+      # unique per run is what lets a release tag republish a commit main has
+      # already published — see "Republishing" at the top of this file.
       - id: deployment
         uses: actions/deploy-pages@v4
+        env:
+          GITHUB_SHA: ${{ github.sha }}-${{ github.run_id }}

--- a/site/README.md
+++ b/site/README.md
@@ -24,6 +24,13 @@ Pushes to `main` build and deploy, as do release tags. Pull requests build witho
 deploying. The workflow can also be run manually (**Actions → docs → Run workflow**)
 to publish out of band.
 
+The sidebar footer names **the last release that was cut** — `git describe --tags
+--abbrev=0`, not the commit being built — so it keeps naming that release while
+`main` moves ahead of the tag. Republishing a commit that has already been published, which is
+exactly what a release tag does, needs a per-run `pages_build_version` and a tag
+policy on the `github-pages` environment; both are set up and explained in the header
+comment of `.github/workflows/pages.yml`. Read that before changing the deploy job.
+
 Checks are **local**, not CI. The workflow only runs Hugo — Relearn renders mermaid in
 the browser, so nothing on the server side needs one.
 


### PR DESCRIPTION
Cutting v0.3.0 exposed two separate faults in the docs publish path. Replaces #30, which
documented only the first half of one of them.

## 1. The footer named a commit, not a release

It read `v0.2.1-33-ga1bcf26` while v0.3.0 was the current release. The workflow used
`git describe --tags --always`, which appends a distance and a hash the moment anything
lands after the tag — and the tag is created *after* the merge that triggers the build,
so a main build never sees it.

Now `git describe --tags --abbrev=0`, which reports the nearest reachable tag. That is
the last release that was cut, whichever commit is being built. It also removes the
`GITHUB_REF_TYPE` special case: on a tag build `--abbrev=0` reports that tag anyway, so
one code path covers branch and tag. Falls back to `dev` in a repo with no tags.

## 2. A release tag could never republish

The tag trigger was added so cutting a release republishes the docs. It failed twice
over, and the second failure is the interesting one.

**First:** the `github-pages` environment only allowed deployments from the branch
`main`, and a tag ref is not a branch. The deploy job was rejected in about a second
with zero steps executed — indistinguishable from the Actions outage we had spent the
previous day working around. Fixed on the environment itself with a `v*` tag policy
(that is repo settings, not this diff; the command is now in the workflow header).

**Then:** with the policy in place, tag deployments ran to completion, reported
`success`, and were never served. Pages keys a deployment by `pages_build_version`, and
`actions/deploy-pages` sends `GITHUB_SHA` for it
([`src/internal/context.js`](https://github.com/actions/deploy-pages/blob/main/src/internal/context.js):
`buildVersion: process.env.GITHUB_SHA`). Tag `v0.3.0` points at `a1bcf26` — the same
commit `main` had already published — so the first deployment of that version won and
every later one was discarded.

Evidence, from the run logs and the live site:

| Deploy | Ref | `pages_build_version` | Result | Served |
|---|---|---|---|---|
| 07:24 | `main` | `a1bcf26…` | success | **yes** |
| 07:27, 07:30, 07:32 | tag `v0.3.0` | `a1bcf26…` | success | no |
| 07:58 | `main`, dispatch | `a1bcf26…` | success | no |

Relearn stamps a cache-busting token equal to the build time on its assets. The site
served `theme.min.css?1786087475` = 07:24:35Z for over an hour after the last of those,
with GitHub Pages and Actions both reporting operational. There is no Pages API to
confirm the discard server-side (`pages/builds/latest` returns 404 for
`build_type: workflow`), so this is inference — but it is the only reading that fits
every data point without invoking a platform fault.

The deploy step now overrides `GITHUB_SHA` with `${{ github.sha }}-${{ github.run_id }}`,
making every deployment a new version.

**Two consequences, both written into the workflow header:** a deploy is no longer ever
a no-op, and the commit shown for a Pages deployment is that composite string rather
than a bare SHA.

## Verification

Local, before pushing: the site built with the CI variable renders
`Documenting Keystone <strong>v0.3.0</strong>`, and `check-layout.py` passes over 45
pages.

After merge, in two steps — the second is the one that actually tests the fix:

1. The push to `main` carries a new SHA, so it would be served regardless. It confirms
   the version fix only.
2. Dispatch `docs` on `main` again: same commit, different run id. If the served asset
   token changes, the duplicate-version problem is gone. If the Pages API rejects a
   `pages_build_version` that is not 40 hex characters, the deploy fails loudly and the
   fallback is a synthetic 40-hex value derived from the run id.

## Documentation review

- **Touched:** `site/README.md` — the "Publishing" section now states that the footer
  names the last cut release, and points at the workflow header before anyone edits the
  deploy job. The workflow's own header comment carries the full diagnosis, including
  the `gh api` command for the environment policy, because Settings → Environments is
  not where anyone looks when a deployment dies instantly.
- **Deliberately not touched:** no HTTP route, recipe or plan field, component state
  behaviour, agent flag or environment variable, security posture, or adapter payload
  changed, so `reference/`, `concepts/`, `security/`, `control-planes/` and the examples
  chapter are unaffected. `HUGO_PARAMS_VERSION` is a CI build variable, not an agent
  one, so `reference/env.md` stays as it is. The version string in `Taskfile.yml` is
  left on `--always --dirty` on purpose: for a binary you want the exact commit, not the
  nearest release.
