### PR TITLE
chore(release): document v0.4.0

### DIFF
--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -17,7 +17,7 @@ enableGitInfo = true
   # with this value. It is committed rather than derived from git because a tag
   # points at a commit Pages has already published, and Pages discards a second
   # deployment of the same commit — see .github/workflows/pages.yml.
-  version = "v0.3.0"
+  version = "v0.4.0"
   editURL = "https://github.com/carlosprados/keystone/edit/develop/site/content/"
   themeVariant = ["auto", "relearn-light", "relearn-dark", "neon"]
   disableLandingPageButton = true


### PR DESCRIPTION
Bumps the version the documentation site names, ahead of cutting `v0.4.0`.

This has to land before the tag: Pages discards a second deployment of a commit it
has already published, so a tag cannot republish the site. Merging this is the
deploy that puts `v0.4.0` in the footer.

After merge:

```
task release:tag RELEASE=v0.4.0
```