### PR TITLE
Point the docs edit link at the branch the site is built from

### DIFF
--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -32,7 +32,11 @@ enableGitInfo = true
   # points at a commit Pages has already published, and Pages discards a second
   # deployment of the same commit — see .github/workflows/pages.yml.
   version = "v0.5.0"
-  editURL = "https://github.com/carlosprados/keystone/edit/develop/site/content/"
+  # The "edit this page" button. It points at `main` because that is the branch
+  # this site is built from: an edit link into any other branch opens a version
+  # of the page the reader is not looking at. It pointed at `develop` until
+  # `develop` had fallen 22 commits behind, which is exactly that failure.
+  editURL = "https://github.com/carlosprados/keystone/edit/main/site/content/"
   # The look follows carlos.enredando.me: dark by default, cyan accent, the
   # Space Grotesk / Inter / JetBrains Mono trio. "auto" leads so a visitor whose
   # system asks for light gets light, exactly as the blog behaves; the two named


### PR DESCRIPTION
## What this changes

The **"edit this page"** button pointed at `develop`. That branch had fallen **22 commits behind `main`** while the work went to `main` by pull request, so every edit link resolved fine and quietly opened an older version of the page than the reader had in front of them — the worst kind of broken, because nothing looks broken.

`main` is the branch `pages.yml` publishes, so `main` is where an edit should start.

One line, plus the comment that says why, so it does not drift back.

`develop` itself stays: `ci.yml` still builds it. It is fast-forwarded to `main` alongside this change so it stops being a stale trap.

## Documentation review

- [x] `site/hugo.toml` — the `editURL` itself, with a comment stating the invariant (edit link and published branch are the same branch)
- [x] Nothing under `site/content/` needed: no route, recipe field, flag, environment variable, `keystonectl` command, security posture or adapter payload changed
- [x] `task openapi` not run — no route or response type touched
- [x] README unchanged — it documents no branch for edits

## Verification

- Built the site and read the emitted link rather than trusting the config: `href="https://github.com/carlosprados/keystone/edit/main/site/content/basics/install.md"`
- That URL answers **200**
- `task docs:check` → 47 pages, layout sound
- `task test` not run: no Go code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
