### PR TITLE
Retire develop and write down the branching flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,15 @@
 name: ci
 
+# main is the only long-lived branch. Work happens on short-lived keystone/*
+# branches that reach main by pull request and are deleted on merge, so the two
+# triggers below cover everything: the PR gate, and the merge that lands it.
 on:
   push:
     branches:
       - main
-      - develop
   pull_request:
     branches:
       - main
-      - develop
 
 permissions:
   contents: read

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,8 +7,10 @@ name: docs
 # `task docs:check:diagrams` before pushing. Relearn renders mermaid in the
 # browser, so nothing here needs one.
 #
-# Deploys from main only: the site documents features as released, and publishing
-# from develop would describe flags that a downloaded binary does not have yet.
+# Deploys from main only. The site documents features as released, so publishing
+# from a branch that has not landed would describe flags a downloaded binary does
+# not have yet. main is also the only long-lived branch, so "the published site"
+# and "the branch of record" are the same thing by construction.
 #
 # Triggers, and why:
 #   - push to main      every merge, so the published docs never lag the branch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,29 @@ The HTTP adapter exposes: `/healthz`, `/metrics`, `/v1/components`, `/v1/plan/st
 
 All agent flags are discoverable via `./keystone --help`. Environment variables are documented in `README.md` (section "Environment Variables"). The agent loads `.env` from the working directory.
 
+## Branches
+
+**`main` is the only long-lived branch.** Work happens on short-lived
+`keystone/<feature-name>` branches that reach `main` by pull request and are
+deleted on merge. There is no `develop`, no release branch, no integration
+branch.
+
+That single branch is load-bearing in three places, which is why nothing else
+gets to be long-lived:
+
+- **CI** gates every PR into `main` and re-runs on the merge (`ci.yml`).
+  Rulesets enforce it: no direct pushes, no history rewriting.
+- **The docs site** publishes from `main` (`pages.yml`), and the site's
+  "edit this page" link points there. Publishing branch and branch of record are
+  the same by construction.
+- **Releases** tag a commit on `main`, and release tags are immutable.
+
+A second long-lived branch existed once. It received no pull requests, published
+nothing, was tagged never, and had no protection — so it drifted 22 commits
+behind while the docs' edit links still pointed at it. Every reader who clicked
+"edit this page" got a stale copy, and nothing looked broken. If a branch is not
+one of the three things above, it is short-lived.
+
 ## Documentation is part of every change
 
 **Doctrine, not a suggestion: no change ships without a documentation review.**

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -34,8 +34,9 @@ enableGitInfo = true
   version = "v0.5.0"
   # The "edit this page" button. It points at `main` because that is the branch
   # this site is built from: an edit link into any other branch opens a version
-  # of the page the reader is not looking at. It pointed at `develop` until
-  # `develop` had fallen 22 commits behind, which is exactly that failure.
+  # of the page the reader is not looking at. It once pointed at a second
+  # long-lived branch that had fallen 22 commits behind, which is exactly that
+  # failure — and the reason there is only one long-lived branch now.
   editURL = "https://github.com/carlosprados/keystone/edit/main/site/content/"
   # The look follows carlos.enredando.me: dark by default, cyan accent, the
   # Space Grotesk / Inter / JetBrains Mono trio. "auto" leads so a visitor whose


### PR DESCRIPTION
## What this changes

The flow already in practice is **trunk-based**: work on a short-lived `keystone/*` branch, pull request into `main`, delete on merge. `develop` sat beside it doing none of the work — no pull requests, nothing published, never tagged, and **no ruleset protecting it** — so it drifted 22 commits behind while the docs' edit links still pointed at it. Every reader who clicked "edit this page" got a stale copy of the page, and nothing looked broken. That was fixed in #36 by moving the link; this removes the branch that made the mistake possible.

- **`ci.yml`** drops `develop` from both triggers. The PR gate plus the merge that lands it now cover every commit that can reach `main`, because nothing else is long-lived.
- **`pages.yml`** stated the deploy rule in terms of `develop`; it now states the invariant, which outlives any branch name.
- **`site/hugo.toml`** — same, for the `editURL` comment.
- **`CLAUDE.md`** gains a **Branches** section. `main` is load-bearing in three places (CI + rulesets, the published site, release tags), so nothing else gets to be long-lived. The convention was implicit before, which is precisely what let it drift.

The `develop` branch itself is deleted after this lands, so CI never references a branch that is already gone.

## Documentation review

- [x] `CLAUDE.md` — new Branches section stating the invariant and why `main` is the only long-lived branch
- [x] `.github/workflows/pages.yml` and `site/hugo.toml` — comments that named `develop` now state the rule instead
- [x] Nothing under `site/content/` needed: no route, recipe field, flag, environment variable, `keystonectl` command, security posture or adapter payload changed. No reader-facing page mentions a branch
- [x] `task openapi` not run — no route or response type touched
- [x] README unchanged — it documents no branching flow

## Verification

- Both workflow files parsed and their triggers inspected rather than eyeballed:
  - `ci.yml` → `push: [main]`, `pull_request: [main]`
  - `pages.yml` → `push: [main]`, path-filtered `pull_request`, `workflow_dispatch`
- `git grep develop` across the tree returns only the intentional mention in `CLAUDE.md` (plus two uses of the English verb)
- `task docs:check` → 47 pages, layout sound
- `go vet ./...` clean; no Go code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
