### PR TITLE
Report the TOML keys the agent does not understand

### DIFF
--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -5,6 +5,7 @@ package adapter
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/carlosprados/keystone/internal/store"
@@ -51,12 +52,29 @@ type CommandHandler interface {
 	GetHealth() *HealthStatus
 }
 
+// ErrInvalidInput marks a failure caused by what the caller submitted rather
+// than by anything wrong on the device. Transports map it to a client error:
+// answering 500 to a malformed plan tells an operator the agent broke, and tells
+// automation to retry — which it will do forever, since the file will not fix
+// itself in the meantime.
+//
+// Wrap with %w at the point the input is judged; check with errors.Is.
+var ErrInvalidInput = errors.New("invalid input")
+
 // PlanStatus represents the current state of the deployment plan.
 type PlanStatus struct {
-	PlanPath   string                `json:"planPath"`
-	Status     string                `json:"status"`
-	Error      string                `json:"error,omitempty"`
-	Components []store.ComponentInfo `json:"components"`
+	PlanPath string `json:"planPath"`
+	Status   string `json:"status"`
+	Error    string `json:"error,omitempty"`
+	// UnknownFields lists keys the applied plan and its recipes carry that this
+	// agent does not understand, each as `"lifecycle.run.restart_polciy"
+	// (line 6)`. It is not an error: the agent may predate the field, and
+	// refusing would strand a device over a recipe newer than its binary. It is
+	// here so that a typo — which is the same thing seen from the other side —
+	// is visible without reading the agent's logs. A dry-run apply refuses
+	// outright instead.
+	UnknownFields []string              `json:"unknownFields,omitempty"`
+	Components    []store.ComponentInfo `json:"components"`
 }
 
 // GraphInfo represents the dependency graph of the current plan.

--- a/internal/adapter/http/http.go
+++ b/internal/adapter/http/http.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/subtle"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -353,7 +354,14 @@ func (a *Adapter) handlePlanApply(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := a.handler.ApplyPlanContent(string(body), dry); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		// A plan the caller got wrong is a 4xx. The distinction is not cosmetic:
+		// a 500 tells automation to retry, and a file with a typo in it will
+		// still have that typo on the next attempt.
+		status := http.StatusInternalServerError
+		if errors.Is(err, adapter.ErrInvalidInput) {
+			status = http.StatusBadRequest
+		}
+		http.Error(w, err.Error(), status)
 		return
 	}
 	w.WriteHeader(http.StatusAccepted)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -67,6 +67,11 @@ type Agent struct {
 	planPath   string
 	planStatus string // idle | applying | running | failed
 	planErr    string
+	// planUnknown holds the keys the current plan and its recipes carry that
+	// this agent does not understand. It is not an error — the agent may simply
+	// predate the field — but it is the difference between a typo that is
+	// invisible and one an operator can see without reading the logs.
+	planUnknown []string
 	// persistence
 	stateDir string
 	// lastSnapshot fingerprints the last snapshot actually written, so an idle

--- a/internal/agent/handler.go
+++ b/internal/agent/handler.go
@@ -30,10 +30,11 @@ func (a *Agent) GetPlanStatus() *adapter.PlanStatus {
 		}
 	}
 	return &adapter.PlanStatus{
-		PlanPath:   a.planPath,
-		Status:     a.planStatus,
-		Error:      a.planErr,
-		Components: components,
+		PlanPath:      a.planPath,
+		Status:        a.planStatus,
+		Error:         a.planErr,
+		UnknownFields: append([]string(nil), a.planUnknown...),
+		Components:    components,
 	}
 }
 

--- a/internal/agent/plan_reconcile.go
+++ b/internal/agent/plan_reconcile.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	semver "github.com/Masterminds/semver/v3"
+	"github.com/carlosprados/keystone/internal/adapter"
 	"github.com/carlosprados/keystone/internal/deploy"
 	"github.com/carlosprados/keystone/internal/recipe"
 	sysrt "github.com/carlosprados/keystone/internal/runtime"
@@ -34,6 +35,39 @@ type plannedState struct {
 	indegrees map[string]int
 }
 
+// unknownFieldReports names every key the plan and its recipes carried that the
+// agent does not understand, each already carrying its own line number.
+//
+// They are reported rather than refused because one recipe is published to many
+// agents: an agent older than a field must still run it. What that tolerance
+// costs is a silent typo, so the list surfaces twice — a dry run fails on it,
+// where the author is one edit away from a fix, and an apply logs it and puts it
+// in the plan status, where an operator can at least see it.
+func (p *plannedState) unknownFieldReports() []string {
+	var reports []string
+	for _, u := range p.plan.UnknownFields {
+		reports = append(reports, fmt.Sprintf("plan %s: %s", p.path, u))
+	}
+	// Sorted by component name: map iteration order would otherwise reshuffle
+	// the message between two runs over the same unchanged files.
+	for _, name := range sortedComponentNames(p.byName) {
+		comp := p.byName[name]
+		for _, u := range comp.rec.UnknownFields {
+			reports = append(reports, fmt.Sprintf("recipe %s (component %s): %s", comp.item.RecipePath, name, u))
+		}
+	}
+	return reports
+}
+
+func sortedComponentNames(m map[string]*plannedComponent) []string {
+	names := make([]string, 0, len(m))
+	for name := range m {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
 type reconcileActions struct {
 	stopTargets  map[string]bool
 	startTargets map[string]bool
@@ -56,6 +90,17 @@ func (a *Agent) applyPlanReconcileUnlocked(planPath string, dry, allowRollback b
 		return err
 	}
 
+	// A dry run is the authoring path: this is the one place where an unknown
+	// key is worth refusing, because the person who can fix it is right here and
+	// nothing is deployed yet. It returns before any state is touched.
+	unknown := desired.unknownFieldReports()
+	if dry && len(unknown) > 0 {
+		return fmt.Errorf("%w: unknown fields, which the agent would ignore: %s", adapter.ErrInvalidInput, strings.Join(unknown, "; "))
+	}
+	for _, u := range unknown {
+		log.Printf("[agent] WARNING ignoring %s — the agent does not know this field; a dry run rejects it", u)
+	}
+
 	a.mu.RLock()
 	oldPlanPath := a.planPath
 	oldPlanComps := append([]state.PlanComponent(nil), a.planComps...)
@@ -72,6 +117,7 @@ func (a *Agent) applyPlanReconcileUnlocked(planPath string, dry, allowRollback b
 		a.planPath = planPath
 		a.planStatus = "dry-run"
 		a.planErr = ""
+		a.planUnknown = nil
 		a.planComps = desired.planMap
 		a.mu.Unlock()
 		a.persistSnapshot()
@@ -83,6 +129,7 @@ func (a *Agent) applyPlanReconcileUnlocked(planPath string, dry, allowRollback b
 	a.planPath = planPath
 	a.planStatus = "applying"
 	a.planErr = ""
+	a.planUnknown = unknown
 	a.mu.Unlock()
 	a.persistSnapshot()
 

--- a/internal/agent/unknown_fields_test.go
+++ b/internal/agent/unknown_fields_test.go
@@ -1,0 +1,108 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/carlosprados/keystone/internal/deploy"
+	"github.com/carlosprados/keystone/internal/recipe"
+	"github.com/carlosprados/keystone/internal/store"
+)
+
+// The agent tolerates a key it does not know, because a recipe is published to
+// a fleet where some agents predate the field. These tests pin the other half
+// of that bargain: what it tolerates, it has to name.
+
+func TestUnknownFieldReportsNamesPlanAndRecipes(t *testing.T) {
+	ps := &plannedState{
+		path: "plan.toml",
+		plan: &deploy.Plan{UnknownFields: []string{`"components.recipie" (line 3)`}},
+		byName: map[string]*plannedComponent{
+			// Deliberately out of alphabetical order in the map literal: the
+			// report must not reshuffle between two runs over the same files.
+			"web": {
+				item: deploy.Component{Name: "web", RecipePath: "recipes/web.toml"},
+				rec:  &recipe.Recipe{UnknownFields: []string{`"lifecycle.run.restart_polciy" (line 6)`}},
+			},
+			"api": {
+				item: deploy.Component{Name: "api", RecipePath: "recipes/api.toml"},
+				rec:  &recipe.Recipe{UnknownFields: []string{`"metadata.autor" (line 4)`}},
+			},
+			"db": {
+				item: deploy.Component{Name: "db", RecipePath: "recipes/db.toml"},
+				rec:  &recipe.Recipe{},
+			},
+		},
+	}
+
+	got := ps.unknownFieldReports()
+	if len(got) != 3 {
+		t.Fatalf("got %d reports, want 3: %v", len(got), got)
+	}
+	if !strings.HasPrefix(got[0], "plan plan.toml:") {
+		t.Errorf("first report should be the plan's, got %q", got[0])
+	}
+	if !strings.Contains(got[1], "component api") || !strings.Contains(got[1], "recipes/api.toml") {
+		t.Errorf("second report should name component api and its recipe, got %q", got[1])
+	}
+	if !strings.Contains(got[2], "component web") {
+		t.Errorf("third report should name component web, got %q", got[2])
+	}
+	for _, r := range got {
+		if strings.Contains(r, "component db") {
+			t.Errorf("a component with nothing unknown must not be reported: %q", r)
+		}
+	}
+}
+
+// Running the same state twice must produce the same message. Map iteration
+// order is randomised per run in Go, so an unsorted implementation passes once
+// and fails later, in someone else's build.
+func TestUnknownFieldReportsAreStable(t *testing.T) {
+	build := func() *plannedState {
+		byName := map[string]*plannedComponent{}
+		for _, n := range []string{"zeta", "alpha", "mu", "beta", "omega"} {
+			byName[n] = &plannedComponent{
+				item: deploy.Component{Name: n, RecipePath: "recipes/" + n + ".toml"},
+				rec:  &recipe.Recipe{UnknownFields: []string{`"metadata.autor" (line 4)`}},
+			}
+		}
+		return &plannedState{path: "plan.toml", plan: &deploy.Plan{}, byName: byName}
+	}
+	first := strings.Join(build().unknownFieldReports(), "\n")
+	for i := 0; i < 20; i++ {
+		if got := strings.Join(build().unknownFieldReports(), "\n"); got != first {
+			t.Fatalf("report order is not stable\nfirst:\n%s\nlater:\n%s", first, got)
+		}
+	}
+}
+
+func TestNoReportsWhenEverythingIsUnderstood(t *testing.T) {
+	ps := &plannedState{
+		path:   "plan.toml",
+		plan:   &deploy.Plan{},
+		byName: map[string]*plannedComponent{"api": {rec: &recipe.Recipe{}}},
+	}
+	if got := ps.unknownFieldReports(); len(got) != 0 {
+		t.Errorf("clean plan produced reports: %v", got)
+	}
+}
+
+// The list has to reach an operator who is looking at the API rather than the
+// agent's stdout, which is the usual case on a device.
+func TestPlanStatusSurfacesUnknownFields(t *testing.T) {
+	a := &Agent{comps: store.NewMemoryStore()}
+	a.planStatus = "running"
+	a.planUnknown = []string{`recipe recipes/api.toml (component api): "metadata.autor" (line 4)`}
+
+	st := a.GetPlanStatus()
+	if len(st.UnknownFields) != 1 || !strings.Contains(st.UnknownFields[0], "metadata.autor") {
+		t.Fatalf("UnknownFields = %v, want the recorded report", st.UnknownFields)
+	}
+
+	// The caller must not be handed the agent's own slice to mutate.
+	st.UnknownFields[0] = "tampered"
+	if a.planUnknown[0] == "tampered" {
+		t.Error("GetPlanStatus handed out the agent's backing array")
+	}
+}

--- a/internal/deploy/plan.go
+++ b/internal/deploy/plan.go
@@ -11,6 +11,12 @@ import (
 // Plan defines a minimal deployment plan for Keystone demo/apply.
 type Plan struct {
 	Components []Component `toml:"components"`
+
+	// UnknownFields lists keys the file carried that this struct does not
+	// declare. Same contract as Recipe.UnknownFields: reported, not rejected,
+	// so the authoring path can fail on them and the runtime path cannot be
+	// stranded by them.
+	UnknownFields []string `toml:"-"`
 }
 
 type Component struct {
@@ -23,10 +29,15 @@ func Load(path string) (*Plan, error) {
 	if err != nil {
 		return nil, err
 	}
+	// A plan is two fields per component, so a misspelling here is both easy and
+	// total — `recipie = "..."` leaves the path empty. Recorded, not rejected;
+	// the dry run is what turns it into an error.
 	var p Plan
-	if err := toml.Unmarshal(b, &p); err != nil {
+	unknown, err := validate.DecodeTOML(b, &p)
+	if err != nil {
 		return nil, err
 	}
+	p.UnknownFields = unknown
 	var m map[string]any
 	if err := toml.Unmarshal(b, &m); err != nil {
 		return nil, err

--- a/internal/deploy/plan_test.go
+++ b/internal/deploy/plan_test.go
@@ -3,6 +3,7 @@ package deploy
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -37,5 +38,31 @@ name = "svc"
 `)
 	if _, err := Load(p); err == nil {
 		t.Fatal("plan with a component missing 'recipe' was accepted, want error")
+	}
+}
+
+// A plan is two keys per component, so a misspelling is total: `recipie` leaves
+// the path empty and the component resolves to nothing. Loading still succeeds,
+// for the same fleet reason recipes tolerate unknown keys, but the plan carries
+// what it did not understand so the dry run can refuse it.
+func TestLoadPlanReportsUnknownFields(t *testing.T) {
+	p := writePlan(t, `
+[[components]]
+name = "svc"
+recipe = "svc.recipe.toml"
+recipie = "typo.recipe.toml"
+`)
+	plan, err := Load(p)
+	if err != nil {
+		t.Fatalf("plan with an unknown field was rejected: %v", err)
+	}
+	if len(plan.UnknownFields) != 1 {
+		t.Fatalf("UnknownFields = %v, want exactly one entry", plan.UnknownFields)
+	}
+	if !strings.Contains(plan.UnknownFields[0], "recipie") {
+		t.Errorf("report %q does not name the offending key", plan.UnknownFields[0])
+	}
+	if plan.Components[0].RecipePath != "svc.recipe.toml" {
+		t.Errorf("RecipePath = %q, the real key must still win", plan.Components[0].RecipePath)
 	}
 }

--- a/internal/recipe/loader.go
+++ b/internal/recipe/loader.go
@@ -23,15 +23,21 @@ func Unmarshal(b []byte) (*Recipe, error) {
 	return parseAndValidate(b)
 }
 
-// parseAndValidate decodes a recipe and enforces both the path-safety of its
-// metadata and the JSON-Schema contract. Schema errors are now returned (no
-// longer best-effort/discarded), so malformed recipes are rejected before they
-// can drive process/container execution.
+// parseAndValidate decodes a recipe and enforces the path-safety of its
+// metadata and the JSON-Schema contract. Schema errors are returned (no longer
+// best-effort/discarded), so malformed recipes are rejected before they can
+// drive process/container execution.
+//
+// Unknown keys are recorded on the Recipe rather than rejected: the authoring
+// path fails on them, the runtime path logs them. See validate.DecodeTOML for
+// the two failure modes that split.
 func parseAndValidate(b []byte) (*Recipe, error) {
 	var r Recipe
-	if err := toml.Unmarshal(b, &r); err != nil {
+	unknown, err := validate.DecodeTOML(b, &r)
+	if err != nil {
 		return nil, err
 	}
+	r.UnknownFields = unknown
 	if err := validateMetadata(&r); err != nil {
 		return nil, err
 	}

--- a/internal/recipe/loader_test.go
+++ b/internal/recipe/loader_test.go
@@ -1,6 +1,9 @@
 package recipe
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 const processRecipe = `
 [metadata]
@@ -154,5 +157,66 @@ command = "./x"
 		if _, err := Unmarshal([]byte(toml)); err == nil {
 			t.Errorf("%s: Unmarshal accepted an invalid recipe, want error", name)
 		}
+	}
+}
+
+// TestUnmarshalReportsUnknownFields is the other half of
+// TestUnmarshalIgnoresUnknownFields. Tolerating a field an older agent has
+// never heard of is what lets a recipe reach a mixed-version fleet; the price
+// is that a typo looks exactly the same from here. So the loader still accepts
+// the recipe, but it says what it did not understand — and it says where, since
+// a key alone is hard to find in a file that repeats [[artifacts]] four times.
+//
+// If this test fails while TestUnmarshalIgnoresUnknownFields still passes, the
+// tolerance became silent again, which is the bug this pair exists to prevent.
+func TestUnmarshalReportsUnknownFields(t *testing.T) {
+	const withTypo = `
+[metadata]
+name = "app"
+version = "1.0.0"
+[lifecycle.run]
+restart_polciy = "never"
+[lifecycle.run.exec]
+command = "./app"
+`
+	r, err := Unmarshal([]byte(withTypo))
+	if err != nil {
+		t.Fatalf("recipe with an unknown field was rejected: %v", err)
+	}
+	if len(r.UnknownFields) != 1 {
+		t.Fatalf("UnknownFields = %v, want exactly one entry", r.UnknownFields)
+	}
+	got := r.UnknownFields[0]
+	if !strings.Contains(got, "lifecycle.run.restart_polciy") {
+		t.Errorf("report %q does not name the offending key", got)
+	}
+	if !strings.Contains(got, "line 6") {
+		t.Errorf("report %q does not carry the line number", got)
+	}
+	// The typo is the whole point: the field it was aiming at stayed unset, and
+	// an empty restart policy resolves to "always" further down.
+	if r.Lifecycle.Run.RestartPolicy != "" {
+		t.Errorf("RestartPolicy = %q, want empty — the typo must not have set it", r.Lifecycle.Run.RestartPolicy)
+	}
+}
+
+// A recipe whose keys are all understood must report nothing, or the warning
+// becomes noise an operator learns to scroll past.
+func TestUnmarshalReportsNothingWhenClean(t *testing.T) {
+	const clean = `
+[metadata]
+name = "app"
+version = "1.0.0"
+[lifecycle.run]
+restart_policy = "never"
+[lifecycle.run.exec]
+command = "./app"
+`
+	r, err := Unmarshal([]byte(clean))
+	if err != nil {
+		t.Fatalf("valid recipe rejected: %v", err)
+	}
+	if len(r.UnknownFields) != 0 {
+		t.Errorf("UnknownFields = %v, want none", r.UnknownFields)
 	}
 }

--- a/internal/recipe/types.go
+++ b/internal/recipe/types.go
@@ -171,6 +171,17 @@ type Recipe struct {
 	Lifecycle    Lifecycle    `toml:"lifecycle"`
 	Resources    Resources    `toml:"resources"`
 	Dependencies []Dependency `toml:"dependencies"`
+
+	// UnknownFields lists the keys the file carried that this struct does not
+	// declare, each as `"lifecycle.run.restart_polciy" (line 6)`. Loading does
+	// not fail on them — an agent older than a field must still run the recipe,
+	// which is what lets a new field reach a mixed-version fleet. A dry run
+	// turns this list into an error and the agent logs it, so a typo is loud
+	// where it is cheap to fix and visible where it is not.
+	//
+	// Not a TOML field: it is derived from the parse, and a recipe that tried to
+	// set it would be reporting on itself.
+	UnknownFields []string `toml:"-"`
 }
 
 // Health probe definition

--- a/internal/validate/stricttoml.go
+++ b/internal/validate/stricttoml.go
@@ -1,0 +1,87 @@
+package validate
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+// DecodeTOML decodes a TOML document into v and reports, without failing, every
+// key the document carries that v does not declare.
+//
+// Two failure modes pull in opposite directions here, and this signature is how
+// the codebase holds both:
+//
+//   - A typo is silent and changes behaviour. `restart_polciy = "never"` used to
+//     parse cleanly and leave RestartPolicy empty, and an empty restart policy
+//     resolves to "always" — a component the author asked never to restart
+//     restarted forever, with no diagnostic. The same holds for a key written
+//     under the wrong table header, which TOML makes easy.
+//   - Rejecting unknown keys outright breaks a mixed-version fleet. One recipe
+//     is published to many agents; an agent that predates a field must ignore
+//     it, not refuse the recipe. That property is pinned by
+//     TestUnmarshalIgnoresUnknownFields and it is why [artifacts.delta] could
+//     ship at all.
+//
+// So the decode never fails on an unknown key: it returns them. Callers decide.
+// The authoring path — a dry-run apply — turns the list into an error, where it
+// costs one edit. The runtime path logs it and carries on, where refusing would
+// strand a device over a field its agent is simply too old to know about.
+//
+// The struct tags are the source of truth, deliberately. The alternative was
+// "additionalProperties": false on the JSON Schemas in this package, which would
+// mean hand-maintaining a second list of every field — and a schema that forgets
+// a field rejects a valid recipe, which is worse than the bug being fixed. Here
+// the accepted set cannot drift from the set the program actually reads.
+//
+// Each entry is rendered as `"lifecycle.run.restart_polciy" (line 6)`: the key
+// alone is not enough to find it in a file that repeats [[artifacts]] four times.
+func DecodeTOML(b []byte, v any) (unknown []string, err error) {
+	dec := toml.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields()
+
+	// A strict decode still populates v completely; the unknown keys come back
+	// as an error alongside a fully decoded value. Verified, not assumed — one
+	// pass is enough, and a second lax decode would only invite the two to
+	// disagree.
+	err = dec.Decode(v)
+	if err == nil {
+		return nil, nil
+	}
+
+	var strict *toml.StrictMissingError
+	if !errors.As(err, &strict) {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{}, len(strict.Errors))
+	for i := range strict.Errors {
+		key := strings.Join(strict.Errors[i].Key(), ".")
+		row, _ := strict.Errors[i].Position()
+		desc := fmt.Sprintf("%q (line %d)", key, row)
+		if _, dup := seen[desc]; dup {
+			continue
+		}
+		seen[desc] = struct{}{}
+		unknown = append(unknown, desc)
+	}
+	sort.Strings(unknown)
+	return unknown, nil
+}
+
+// UnknownFieldsError renders a list from DecodeTOML as the error the authoring
+// path returns. Kept next to the decoder so both sides word it identically.
+func UnknownFieldsError(unknown []string) error {
+	if len(unknown) == 0 {
+		return nil
+	}
+	noun := "unknown field"
+	if len(unknown) > 1 {
+		noun = "unknown fields"
+	}
+	return fmt.Errorf("%s: %s", noun, strings.Join(unknown, ", "))
+}

--- a/site/content/concepts/plans.md
+++ b/site/content/concepts/plans.md
@@ -45,6 +45,11 @@ curl -X POST --data-binary @plan.toml "http://127.0.0.1:8080/v1/plan/apply?dry=t
 A dry run logs the stop, start and no-touch sets and updates the reported plan
 status to `dry-run`, but installs and starts nothing.
 
+It is also stricter than a real apply on one point: it **refuses any key the
+agent does not recognise**, where an apply accepts it and reports it. That is
+deliberate — see [the TOML cheat sheet](../../reference/toml/#traps) for why the
+two differ and which one you want when.
+
 ## What an apply actually does
 
 ```mermaid

--- a/site/content/reference/api/openapi.yaml
+++ b/site/content/reference/api/openapi.yaml
@@ -594,6 +594,10 @@ components:
           type: string
         status:
           type: string
+        unknownFields:
+          items:
+            type: string
+          type: array
       type: object
     AdapterRestartDryResult:
       properties:

--- a/site/content/reference/schemas.md
+++ b/site/content/reference/schemas.md
@@ -151,4 +151,7 @@ curl -X POST --data-binary @plan.toml "localhost:8080/v1/plan/apply?dry=true"
 ```
 
 A dry run loads and validates every recipe, verifies signatures and computes the
-reconcile plan — without installing or starting anything.
+reconcile plan — without installing or starting anything. It also rejects any key
+the agent does not recognise, which a real apply tolerates on purpose so that a
+recipe can outrun the agents it is published to. The
+[TOML cheat sheet](../toml/#traps) has that trade in full.

--- a/site/content/reference/toml.md
+++ b/site/content/reference/toml.md
@@ -1,19 +1,26 @@
 +++
 title = "TOML cheat sheet"
 weight = 74
-description = "The four constructs every recipe and plan is made of, and the mistakes the parser will not catch for you."
+description = "The four constructs every recipe and plan is made of, and where a misspelled field shows up."
 +++
 
 Recipes and plans are TOML, and nothing else. The whole format reduces to four
-constructs — this page is those four, the shape they build, and the handful of
-mistakes that do **not** produce an error message.
+constructs — this page is those four, the shape they build, and the mistakes
+worth knowing about.
 
 {{% notice style="warning" title="Read this first" %}}
-**A misspelled field name is not an error.** Keystone ignores keys it does not
-recognise, so `restart_polciy = "never"` parses cleanly, sets nothing, and the
-component ends up with the default — `always`. You asked for a process that never
-restarts and you got one that restarts forever, silently. See
-[Traps](#traps-the-parser-will-not-catch) before you trust a file you have edited by hand.
+**A misspelled field name does not stop an apply.** Keystone ignores keys it does
+not recognise, on purpose: one recipe is published to many agents, and an agent
+older than a field has to run the recipe rather than refuse it. The cost is that
+`restart_polciy = "never"` sets nothing, and the component falls back to the
+default — `always`.
+
+So the agent reports what it ignored instead of hiding it, and a **dry run
+refuses it outright**. Run one before you trust a file you have edited by hand:
+
+```bash
+curl -X POST --data-binary @plan.toml "localhost:8080/v1/plan/apply?dry=true"
+```
 {{% /notice %}}
 
 ## The four constructs
@@ -202,14 +209,17 @@ recipe = "com.acme.api:1.4.0"                # …or name:version from the store
 There is no ordering in a plan. Order comes from `[[dependencies]]` in the
 recipes — see [Dependencies](../../concepts/dependencies/).
 
-## Traps the parser will not catch
+## Traps
 
-### An unknown key is silently ignored
+### An unknown key does not stop the apply
 
-The decoder does not run in strict mode and the schema does not forbid extra
-properties, so anything Keystone does not recognise is dropped without a word.
-The failure is not that the field is missing — it is that the **default takes
-over**, and the defaults are deliberately permissive:
+Keystone accepts a key it does not recognise. That is deliberate, and it is what
+makes a fleet upgradeable: one recipe is published to many devices, and an agent
+whose binary predates a field must still run the recipe rather than refuse it.
+`[artifacts.delta]` reached existing fleets on exactly that property.
+
+The cost is that a typo looks identical to a field from the future. The field you
+meant stays unset, and the **default takes over**:
 
 ```toml
 [lifecycle.run]
@@ -219,10 +229,22 @@ restart_polciy = "never"       # typo: ignored → restart_policy stays empty
 An empty `restart_policy` resolves to `always`. The component you wanted dead
 after one run restarts forever.
 
+What the agent will not do is hide it. Every key it did not understand is named,
+with its line, in three places:
+
+| Where | What happens |
+|---|---|
+| **A dry run** | **Refuses the plan.** This is the authoring path: you are one edit away from a fix and nothing is deployed yet |
+| The agent's log | `WARNING ignoring recipe recipes/api.toml (component api): "lifecycle.run.restart_polciy" (line 6)` |
+| `GET /v1/plan/status` | an `unknownFields` array, for an operator who is not reading stdout |
+
+If `unknownFields` is non-empty on a device, either that agent is older than the
+recipe — which is fine and expected mid-rollout — or somebody has a typo.
+
 ### A key can land in the wrong table without complaint
 
-A key belongs to the header above it. This is valid TOML, and it does the wrong
-thing for the same reason as the typo:
+A key belongs to the header above it. This is valid TOML, and it lands as an
+unknown field for the same reason the typo does:
 
 ```toml
 [lifecycle.run.exec]
@@ -231,12 +253,13 @@ restart_policy = "never"       # this is exec.restart_policy — nothing reads i
 ```
 
 Put scalars **before** the sub-table headers, or you will keep adding keys to the
-last table you opened rather than the one you meant.
+last table you opened rather than the one you meant. A dry run catches this one
+too.
 
-### What *is* caught
+### What is rejected outright
 
-Not everything slips through. A wrong **value** is rejected loudly, even though a
-wrong **key** is not:
+A wrong **value** never gets the benefit of the doubt, at any stage — there is no
+fleet-compatibility argument for a value the schema already enumerates:
 
 ```
 restart_policy = "sometimes"
@@ -244,9 +267,10 @@ restart_policy = "sometimes"
 
 version = 1.4
   → toml: float cannot be assigned to string
-```
 
-So: types and enumerations are enforced, field names are not.
+[artifacts]                    # single brackets on a repeatable table
+  → toml: cannot store a table in a slice
+```
 
 ### `capabilities = []` is not the same as omitting it
 
@@ -268,9 +292,19 @@ curl -X POST --data-binary @plan.toml "localhost:8080/v1/plan/apply?dry=true"
 A dry run parses the plan, loads every recipe, verifies signatures, enforces the
 schema and computes the reconcile plan — without installing or starting anything.
 It catches malformed TOML, bad types, invalid enum values, missing required
-fields and unresolvable dependencies.
+fields, unresolvable dependencies **and every key the agent does not recognise**,
+which a real apply deliberately tolerates.
 
-**It does not catch a misspelled field name**, for the reason above. For a file
-you have hand-edited, the check that works is reading back what the agent
-actually loaded — `GET /v1/plan/status` and the component's behaviour — rather
-than trusting that a clean apply means the file said what you meant.
+That last one is why a dry run is worth running on a file you have hand-edited
+even when you are sure of it: it is the only place a misspelled field is an
+error rather than a line in a log.
+
+```
+unknown fields, which the agent would ignore:
+  recipe recipes/api.toml (component api): "lifecycle.run.restart_polciy" (line 6)
+```
+
+One caveat worth stating: a dry run is checked against **the agent you ran it
+on**. A recipe using a field newer than that agent's binary will be rejected by
+it and accepted by a newer one — which is the same tolerance seen from the other
+end. Run the dry run against an agent at least as new as the recipe.


### PR DESCRIPTION
## What this changes

A misspelled field used to be invisible. `restart_polciy = "never"` parsed cleanly, left `RestartPolicy` empty, and an empty restart policy resolves to `always` — **a component the author asked never to restart restarted forever, with no diagnostic anywhere.** The same held for a key written under the wrong table header, which TOML makes easy: a key belongs to the last header above it.

### Why not simply reject unknown keys

Because that breaks the fleet, and the property is deliberate. One recipe is published to many agents; an agent whose binary predates a field has to *run* the recipe rather than refuse it. `TestUnmarshalIgnoresUnknownFields` pins it, and it is why `[artifacts.delta]` could ship to existing fleets at all. Strict decoding turns every new field into a fleet-wide outage whose symptom points nowhere near the change that caused it.

I implemented strict rejection first; that test caught it. This PR is the version that keeps both properties.

### What it does instead

The decoder **reports** rather than refuses, and the two callers differ:

| Path | Behaviour |
|---|---|
| **Dry run** (authoring) | **Fails**, before any state is touched. The author is one edit away from a fix and nothing is deployed |
| **Apply** (runtime) | Accepts, logs a `WARNING` naming the key and its line, and puts the list in `GET /v1/plan/status` as `unknownFields` |

`validate.DecodeTOML` is the single decode. It uses go-toml's strict mode and turns the resulting error into a list, so **the struct tags stay the only source of truth**. `"additionalProperties": false` on the JSON Schemas would have meant hand-maintaining a second list of every field — and a schema that forgets one rejects a valid recipe, which is worse than the bug being fixed.

### A second defect, fixed on the way

A plan the caller got wrong answered **500**. `adapter.ErrInvalidInput` now marks input failures and the HTTP adapter maps it to **400**. A 500 tells automation to retry, and a file with a typo in it will still have that typo next time. 400 was already documented for this route, so this makes the spec true rather than changing it.

## Documentation review

- [x] `site/content/reference/toml.md` — the cheat sheet said "an unknown key is silently ignored" and "a dry run does not catch a misspelled field name". Both were true yesterday and are now wrong; the Traps section is rewritten around where each key surfaces, and states the caveat that a dry run is judged by *the agent you ran it on*
- [x] `site/content/concepts/plans.md` — a dry run is now stricter than an apply on exactly one point; said so
- [x] `site/content/reference/schemas.md` — same, in the validation section
- [x] `task openapi` run and the regenerated spec committed — `PlanStatus` gained `unknownFields`
- [x] `docs/security.md` untouched: no security posture, default or confinement moved
- [x] The examples chapter still works verbatim — no example recipe carries an unknown key (all 15 in the repo were swept before starting)

## Verification

**On a running agent**, not only in tests. Recipe with `restart_polciy` on line 6:

| | Result |
|---|---|
| Dry run | `HTTP 400` — `invalid input: unknown fields, which the agent would ignore: recipe recipes/demo.toml (component demo): "lifecycle.run.restart_polciy" (line 6)` |
| Apply | `HTTP 202`, component starts — fleet tolerance intact |
| `/v1/plan/status` | `"unknownFields": ["recipe recipes/demo.toml (component demo): \"lifecycle.run.restart_polciy\" (line 6)"]` |
| Agent log | `WARNING ignoring recipe … — the agent does not know this field; a dry run rejects it` |
| Typo corrected | dry `202`, apply `202`, `unknownFields` absent — no noise |

Plus:

- Swept **all 15 recipes and plans in the repo** through a strict decode before starting: none carries an unknown key, so nothing here needed an escape hatch
- New tests: reporting and its absence (recipe, plan), report composition, **stability of report order** across 20 builds (map iteration order is randomised per run, so an unsorted implementation passes once and fails in someone else's build), and that `GetPlanStatus` does not hand out the agent's backing array
- `TestUnmarshalIgnoresUnknownFields` still passes — the fleet property is intact
- `go test -race ./...` green, `go vet` clean
- `task docs:check` → 48 pages, layout sound; all 12 TOML blocks on the cheat sheet still parse

## Known gap

A dry run validates against the agent it was sent to. A recipe using a field newer than that agent's binary is rejected by it and accepted by a newer one — the same tolerance seen from the other end. Documented on the page rather than papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
