### PR TITLE
chore(release): document v0.6.0

### DIFF
--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -31,7 +31,7 @@ enableGitInfo = true
   # with this value. It is committed rather than derived from git because a tag
   # points at a commit Pages has already published, and Pages discards a second
   # deployment of the same commit — see .github/workflows/pages.yml.
-  version = "v0.5.0"
+  version = "v0.6.0"
   # The "edit this page" button. It points at `main` because that is the branch
   # this site is built from: an edit link into any other branch opens a version
   # of the page the reader is not looking at. It once pointed at a second


### PR DESCRIPTION
Bumps the version the documentation site names, ahead of cutting `v0.6.0`.

This has to land before the tag: Pages discards a second deployment of a commit it
has already published, so a tag cannot republish the site. Merging this is the
deploy that puts `v0.6.0` in the footer.

After merge:

```
task release:tag RELEASE=v0.6.0
```